### PR TITLE
feat: persist theme setting to backend settings

### DIFF
--- a/frontend/src/components/SettingsView.tsx
+++ b/frontend/src/components/SettingsView.tsx
@@ -4,9 +4,6 @@ import {
   Monitor,
   Sun,
   Moon,
-  Laptop,
-  Terminal,
-  LayoutGrid,
   Download,
   Upload,
   Trash2,
@@ -22,9 +19,9 @@ import {
 } from 'lucide-react'
 import { toast } from 'sonner'
 import { cn } from '@/lib/utils'
-import { useTheme, type ThemeMode } from '@/hooks/useTheme'
 import {
   useSettings,
+  type ThemeMode,
   type Language,
   type Timezone,
   type TimestampFormat,
@@ -35,9 +32,9 @@ import {
 import logoUrl from '@/assets/logo.png'
 
 const APP_VERSION = __APP_VERSION__
-const GITHUB_URL = 'https://github.com/codermast/rocket-leaf'
-const GITHUB_ISSUES_URL = 'https://github.com/codermast/rocket-leaf/issues'
-const GITHUB_RELEASES_URL = 'https://github.com/codermast/rocket-leaf/releases/latest'
+const GITHUB_URL = 'https://github.com/amigoer/rocket-leaf'
+const GITHUB_ISSUES_URL = 'https://github.com/amigoer/rocket-leaf/issues'
+const GITHUB_RELEASES_URL = 'https://github.com/amigoer/rocket-leaf/releases/latest'
 
 const THEME_OPTIONS: { value: ThemeMode; label: string; icon: React.ElementType }[] = [
   { value: 'system', label: '跟随系统', icon: Monitor },
@@ -63,10 +60,34 @@ const UI_FONT_OPTIONS = [
 
 const MONOSPACE_FONTS = ['JetBrains Mono', 'Fira Code', 'Source Code Pro', 'Cascadia Code', 'Consolas', 'Monaco', 'Menlo']
 
+function AppleIcon({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor" className={className}>
+      <path d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.8-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z" />
+    </svg>
+  )
+}
+
+function LinuxIcon({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 128 128" fill="currentColor" className={className}>
+      <path fillRule="evenodd" clipRule="evenodd" d="M113.823 104.595c-1.795-1.478-3.629-2.921-5.308-4.525c-1.87-1.785-3.045-3.944-2.789-6.678c.147-1.573-.216-2.926-2.113-3.452c.446-1.154.864-1.928 1.033-2.753c.188-.92.178-1.887.204-2.834c.264-9.96-3.334-18.691-8.663-26.835c-2.454-3.748-5.017-7.429-7.633-11.066c-4.092-5.688-5.559-12.078-5.633-18.981a47.6 47.6 0 0 0-1.081-9.475C80.527 11.956 77.291 7.233 71.422 4.7c-4.497-1.942-9.152-2.327-13.901-1.084c-6.901 1.805-11.074 6.934-10.996 14.088c.074 6.885.417 13.779.922 20.648c.288 3.893-.312 7.252-2.895 10.34c-2.484 2.969-4.706 6.172-6.858 9.397c-1.229 1.844-2.317 3.853-3.077 5.931c-2.07 5.663-3.973 11.373-7.276 16.5c-1.224 1.9-1.363 4.026-.494 6.199c.225.563.363 1.429.089 1.882c-2.354 3.907-5.011 7.345-10.066 8.095c-3.976.591-4.172 1.314-4.051 5.413c.1 3.337.061 6.705-.28 10.021c-.363 3.555.008 4.521 3.442 5.373c7.924 1.968 15.913 3.647 23.492 6.854c3.227 1.365 6.465.891 9.064-1.763c2.713-2.771 6.141-3.855 9.844-3.859c6.285-.005 12.572.298 18.86.369c1.702.02 2.679.653 3.364 2.199c.84 1.893 2.26 3.284 4.445 3.526c4.193.462 8.013-.16 11.19-3.359c3.918-3.948 8.436-7.066 13.615-9.227c1.482-.619 2.878-1.592 4.103-2.648c2.231-1.922 2.113-3.146-.135-5M62.426 24.12c.758-2.601 2.537-4.289 5.243-4.801c2.276-.43 4.203.688 5.639 3.246c1.546 2.758 2.054 5.64.734 8.658c-1.083 2.474-1.591 2.707-4.123 1.868c-.474-.157-.937-.343-1.777-.652c.708-.594 1.154-1.035 1.664-1.382c1.134-.772 1.452-1.858 1.346-3.148c-.139-1.694-1.471-3.194-2.837-3.175c-1.225.017-2.262 1.167-2.4 2.915c-.086 1.089.095 2.199.173 3.589c-3.446-1.023-4.711-3.525-3.662-7.118m-12.75-2.251c1.274-1.928 3.197-2.314 5.101-1.024c2.029 1.376 3.547 5.256 2.763 7.576c-.285.844-1.127 1.5-1.716 2.241l-.604-.374c-.23-1.253-.276-2.585-.757-3.733c-.304-.728-1.257-1.184-1.919-1.762c-.622.739-1.693 1.443-1.757 2.228c-.088 1.084.477 2.28.969 3.331c.311.661 1.001 1.145 1.713 1.916l-1.922 1.51c-3.018-2.7-3.915-8.82-1.871-11.909M87.34 86.075c-.203 2.604-.5 2.713-3.118 3.098c-1.859.272-2.359.756-2.453 2.964a102 102 0 0 0-.012 7.753c.061 1.77-.537 3.158-1.755 4.393c-6.764 6.856-14.845 10.105-24.512 8.926c-4.17-.509-6.896-3.047-9.097-6.639c.98-.363 1.705-.607 2.412-.894c3.122-1.27 3.706-3.955 1.213-6.277c-1.884-1.757-3.986-3.283-6.007-4.892c-1.954-1.555-3.934-3.078-5.891-4.629c-1.668-1.323-2.305-3.028-2.345-5.188c-.094-5.182.972-10.03 3.138-14.747c1.932-4.209 3.429-8.617 5.239-12.885c.935-2.202 1.906-4.455 3.278-6.388c1.319-1.854 2.134-3.669 1.988-5.94c-.084-1.276-.016-2.562-.016-3.843l.707-.352c1.141.985 2.302 1.949 3.423 2.959c4.045 3.646 7.892 3.813 12.319.67c1.888-1.341 3.93-2.47 5.927-3.652c.497-.294 1.092-.423 1.934-.738c2.151 5.066 4.262 10.033 6.375 15c1.072 2.524 1.932 5.167 3.264 7.547c2.671 4.775 4.092 9.813 4.07 15.272c-.012 2.83.137 5.67-.081 8.482" />
+    </svg>
+  )
+}
+
+function WindowsIcon({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor" className={className}>
+      <path d="M0 3.449L9.75 2.1v9.451H0m10.949-9.602L24 0v11.4H10.949M0 12.6h9.75v9.451L0 20.699M10.949 12.6H24V24l-12.9-1.801" />
+    </svg>
+  )
+}
+
 const DATA_PATHS: { platform: string; path: string; icon: React.ElementType }[] = [
-  { platform: 'macOS', path: '~/Library/Application Support/rocket-leaf/', icon: Laptop },
-  { platform: 'Linux', path: '~/.config/rocket-leaf/', icon: Terminal },
-  { platform: 'Windows', path: '%AppData%\\rocket-leaf\\', icon: LayoutGrid },
+  { platform: 'macOS', path: '~/Library/Application Support/rocket-leaf/', icon: AppleIcon },
+  { platform: 'Linux', path: '~/.config/rocket-leaf/', icon: LinuxIcon },
+  { platform: 'Windows', path: '%AppData%\\rocket-leaf\\', icon: WindowsIcon },
 ]
 
 const TIMESTAMP_FORMAT_OPTIONS: { value: TimestampFormat; label: string }[] = [
@@ -97,7 +118,7 @@ const SETTINGS_NAV: { id: SettingsTabId; label: string; icon: React.ElementType 
 
 function Row({ label, children }: { label: string; children: React.ReactNode }) {
   return (
-    <div className="flex items-center gap-6 py-4">
+    <div className="flex items-center gap-6 py-2.5">
       <span className="w-44 shrink-0 text-[0.9375rem] text-foreground">{label}</span>
       <div className="shrink-0">{children}</div>
     </div>
@@ -124,7 +145,7 @@ function Select<T extends string>({
       title={title}
       aria-label={title}
       className={cn(
-        'rounded-md border border-border/50 bg-background px-3 py-2 text-[0.9375rem] text-foreground focus:outline-none focus:ring-1 focus:ring-border',
+        'h-10 rounded-md border border-border/50 bg-background px-3 text-[0.9375rem] text-foreground focus:outline-none focus:ring-1 focus:ring-border',
         className
       )}
     >
@@ -146,44 +167,30 @@ function Toggle({
   onChange: (v: boolean) => void
   title?: string
 }) {
-  const buttonClass = cn(
-    'relative inline-flex h-5 w-9 shrink-0 rounded-full border transition-all duration-200',
-    checked ? 'border-success/50 bg-success' : 'border-border/50 bg-muted'
-  )
-  const thumbClass = cn(
-    'absolute top-1/2 h-4 w-4 -translate-y-1/2 rounded-full shadow-sm transition-all duration-200',
-    checked
-      ? 'left-[calc(100%-1.125rem)] bg-success-foreground border border-success/30'
-      : 'left-0.5 bg-muted-foreground/80'
-  )
-  return checked ? (
+  return (
     <button
       type="button"
       role="switch"
-      aria-checked="true"
+      aria-checked={checked}
       title={title}
       onClick={() => onChange(!checked)}
-      className={buttonClass}
+      className={cn(
+        'relative inline-flex h-[26px] w-[46px] shrink-0 cursor-pointer items-center rounded-full transition-colors duration-200',
+        checked ? 'bg-success' : 'bg-muted-foreground/30'
+      )}
     >
-      <span className={thumbClass} />
-    </button>
-  ) : (
-    <button
-      type="button"
-      role="switch"
-      aria-checked="false"
-      title={title}
-      onClick={() => onChange(!checked)}
-      className={buttonClass}
-    >
-      <span className={thumbClass} />
+      <span
+        className={cn(
+          'pointer-events-none block h-[22px] w-[22px] rounded-full bg-white shadow-sm transition-transform duration-200',
+          checked ? 'translate-x-[22px]' : 'translate-x-[2px]'
+        )}
+      />
     </button>
   )
 }
 
 export function SettingsView() {
   const [activeTab, setActiveTab] = useState<SettingsTabId>('general')
-  const { mode, setTheme } = useTheme()
   const { settings, setSetting, resetAllSettings, loading } = useSettings()
 
   const copyPath = useCallback(async (path: string) => {
@@ -287,18 +294,18 @@ export function SettingsView() {
           {activeTab === 'general' && (
             <div>
           <Row label="外观主题">
-            <div className="flex rounded-md border border-border/40 bg-background p-0.5">
+            <div className="flex h-10 rounded-md border border-border/40 bg-background p-0.5">
               {THEME_OPTIONS.map(({ value, label, icon: Icon }) => (
                 <button
                   key={value}
                   type="button"
-                  onClick={() => setTheme(value)}
+                  onClick={() => setSetting('theme', value)}
                   className={cn(
-                    'flex items-center gap-1.5 px-2.5 py-1.5 text-xs transition-colors first:rounded-l-md last:rounded-r-md',
-                    mode === value ? 'bg-accent text-accent-foreground' : 'hover:bg-accent/50'
+                    'flex items-center gap-1.5 px-3 text-[0.9375rem] transition-colors first:rounded-l-[5px] last:rounded-r-[5px]',
+                    settings.theme === value ? 'bg-accent text-accent-foreground' : 'hover:bg-accent/50'
                   )}
                 >
-                  <Icon className="h-3.5 w-3.5" />
+                  <Icon className="h-4 w-4" />
                   {label}
                 </button>
               ))}
@@ -318,7 +325,7 @@ export function SettingsView() {
               value={settings.fontSize}
               onChange={(e) => setSetting('fontSize', Number(e.target.value))}
               title="界面字体大小"
-              className="rounded-md border border-border/50 bg-background px-3 py-2 text-[0.9375rem] text-foreground focus:outline-none focus:ring-1 focus:ring-border min-w-[260px]"
+              className="h-10 rounded-md border border-border/50 bg-background px-3 text-[0.9375rem] text-foreground focus:outline-none focus:ring-1 focus:ring-border min-w-[260px]"
             >
               {FONT_SIZE_OPTIONS.map((s) => (
                 <option key={s} value={s}>{s}px</option>
@@ -333,7 +340,7 @@ export function SettingsView() {
                   if (e.target.value !== '__custom__') setSetting('uiFont', e.target.value)
                 }}
                 title="界面字体"
-                className="rounded-md border border-border/50 bg-background px-3 py-2 text-[0.9375rem] text-foreground focus:outline-none focus:ring-1 focus:ring-border min-w-[260px]"
+                className="h-10 rounded-md border border-border/50 bg-background px-3 text-[0.9375rem] text-foreground focus:outline-none focus:ring-1 focus:ring-border min-w-[260px]"
               >
                 {UI_FONT_OPTIONS.map((o) => (
                   <option key={o.value} value={o.value}>{o.label}</option>
@@ -347,7 +354,7 @@ export function SettingsView() {
                   value={settings.uiFont}
                   onChange={(e) => setSetting('uiFont', e.target.value)}
                   placeholder="输入字体名称"
-                  className="rounded-md border border-border/50 bg-background px-3 py-2 text-[0.9375rem] text-foreground focus:outline-none focus:ring-1 focus:ring-border w-[160px]"
+                  className="h-10 rounded-md border border-border/50 bg-background px-3 text-[0.9375rem] text-foreground focus:outline-none focus:ring-1 focus:ring-border w-[160px]"
                 />
               )}
             </div>
@@ -361,7 +368,7 @@ export function SettingsView() {
                   else setSetting('monospaceFont', e.target.value)
                 }}
                 title="代码字体"
-                className="rounded-md border border-border/50 bg-background px-3 py-2 text-[0.9375rem] text-foreground focus:outline-none focus:ring-1 focus:ring-border min-w-[260px]"
+                className="h-10 rounded-md border border-border/50 bg-background px-3 text-[0.9375rem] text-foreground focus:outline-none focus:ring-1 focus:ring-border min-w-[260px]"
               >
                 {MONOSPACE_FONTS.map((f) => (
                   <option key={f} value={f}>{f}</option>
@@ -373,7 +380,7 @@ export function SettingsView() {
                   value={settings.monospaceFont}
                   onChange={(e) => setSetting('monospaceFont', e.target.value)}
                   placeholder="输入字体名称"
-                  className="rounded-md border border-border/50 bg-background px-3 py-2 text-[0.9375rem] text-foreground focus:outline-none focus:ring-1 focus:ring-border w-[160px]"
+                  className="h-10 rounded-md border border-border/50 bg-background px-3 text-[0.9375rem] text-foreground focus:outline-none focus:ring-1 focus:ring-border w-[160px]"
                 />
               )}
             </div>
@@ -399,7 +406,7 @@ export function SettingsView() {
               onChange={(e) => setSetting('connectTimeoutMs', Number(e.target.value) || 3000)}
               title="连接超时"
               aria-label="连接超时毫秒"
-              className="w-20 rounded-md border border-border/50 bg-background px-2 py-1.5 text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-border"
+              className="w-20 h-10 rounded-md border border-border/50 bg-background px-3 text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-border"
             />
           </Row>
           <Row label="请求超时 (ms)">
@@ -412,7 +419,7 @@ export function SettingsView() {
               onChange={(e) => setSetting('requestTimeoutMs', Number(e.target.value) || 5000)}
               title="请求超时"
               aria-label="请求超时毫秒"
-              className="w-20 rounded-md border border-border/50 bg-background px-2 py-1.5 text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-border"
+              className="w-20 h-10 rounded-md border border-border/50 bg-background px-3 text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-border"
             />
           </Row>
           <Row label="默认 AccessKey">
@@ -421,7 +428,7 @@ export function SettingsView() {
               value={settings.globalAccessKey}
               onChange={(e) => setSetting('globalAccessKey', e.target.value)}
               placeholder="新建连接时自动填充"
-              className="w-48 rounded-md border border-border/50 bg-background px-2 py-1.5 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-border"
+              className="w-48 h-10 rounded-md border border-border/50 bg-background px-3 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-border"
             />
           </Row>
           <Row label="默认 SecretKey">
@@ -430,7 +437,7 @@ export function SettingsView() {
               value={settings.globalSecretKey}
               onChange={(e) => setSetting('globalSecretKey', e.target.value)}
               placeholder="新建连接时自动填充"
-              className="w-48 rounded-md border border-border/50 bg-background px-2 py-1.5 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-border"
+              className="w-48 h-10 rounded-md border border-border/50 bg-background px-3 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-border"
             />
           </Row>
           <Row label="跳过 TLS 校验">
@@ -461,7 +468,7 @@ export function SettingsView() {
                   value={settings.proxyHost}
                   onChange={(e) => setSetting('proxyHost', e.target.value)}
                   placeholder="host"
-                  className="w-36 rounded-md border border-border/50 bg-background px-2 py-1.5 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-border"
+                  className="w-36 h-10 rounded-md border border-border/50 bg-background px-3 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-border"
                 />
               </Row>
               <Row label="代理端口">
@@ -470,7 +477,7 @@ export function SettingsView() {
                   value={settings.proxyPort}
                   onChange={(e) => setSetting('proxyPort', e.target.value)}
                   placeholder="port"
-                  className="w-20 rounded-md border border-border/50 bg-background px-2 py-1.5 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-border"
+                  className="w-20 h-10 rounded-md border border-border/50 bg-background px-3 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-border"
                 />
               </Row>
             </>
@@ -516,7 +523,7 @@ export function SettingsView() {
               }
               title="消息截断阈值"
               aria-label="消息截断阈值 KB"
-              className="w-20 rounded-md border border-border/50 bg-background px-2 py-1.5 text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-border"
+              className="w-20 h-10 rounded-md border border-border/50 bg-background px-3 text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-border"
             />
           </Row>
           <Row label="单页拉取数量">
@@ -524,7 +531,7 @@ export function SettingsView() {
               value={settings.fetchLimit}
               onChange={(e) => setSetting('fetchLimit', Number(e.target.value) as FetchLimit)}
               title="单页拉取数量"
-              className="rounded-md border border-border/50 bg-background px-2 py-1.5 text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-border"
+              className="h-10 rounded-md border border-border/50 bg-background px-3 text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-border"
             >
               {FETCH_LIMIT_OPTIONS.map((o) => (
                 <option key={o.value} value={o.value}>
@@ -576,27 +583,32 @@ export function SettingsView() {
           )}
 
           {activeTab === 'about' && (
-            <div>
-          <div className="border-b border-border/40 px-3 py-2.5">
-            <div className="flex items-center gap-3">
-              <img src={logoUrl} alt="" className="h-10 w-10 shrink-0 object-contain" aria-hidden />
+            <div className="space-y-5">
+          {/* App Info Card */}
+          <div className="rounded-lg border border-border/40 bg-muted/10 p-5">
+            <div className="flex items-start gap-4">
+              <img src={logoUrl} alt="" className="h-14 w-14 shrink-0 rounded-xl object-contain" aria-hidden />
               <div className="min-w-0 flex-1">
-                <p className="text-sm font-medium text-foreground">Rocket-Leaf</p>
-                <p className="mt-0.5 text-xs text-muted-foreground">
+                <h2 className="text-base font-semibold text-foreground">Rocket-Leaf</h2>
+                <p className="mt-1 text-sm leading-relaxed text-muted-foreground">
                   A lightweight, cross-platform RocketMQ client built with Go and Wails.
                 </p>
-                <p className="mt-0.5 text-xs text-muted-foreground">
+                <p className="text-sm leading-relaxed text-muted-foreground">
                   一款基于 Wails 构建的轻量级、跨平台 RocketMQ 管理客户端。
                 </p>
-                <p className="mt-1.5 text-[11px] text-muted-foreground/80">版本 {APP_VERSION}</p>
+                <span className="mt-2 inline-block rounded-full bg-muted/60 px-2.5 py-0.5 text-xs text-muted-foreground">
+                  v{APP_VERSION}
+                </span>
               </div>
             </div>
           </div>
-          <div className="flex flex-wrap gap-2 p-3">
+
+          {/* Quick Links */}
+          <div className="flex flex-wrap gap-2.5">
             <button
               type="button"
               onClick={handleCheckUpdate}
-              className="flex items-center gap-2 rounded-md border border-border/50 bg-background px-3 py-2 text-sm text-foreground hover:bg-accent/50 transition-colors"
+              className="flex h-10 items-center gap-2 rounded-lg border border-border/50 bg-background px-4 text-sm text-foreground hover:bg-accent/50 transition-colors"
             >
               <RefreshCw className="h-4 w-4" />
               检查更新
@@ -605,7 +617,7 @@ export function SettingsView() {
               href={GITHUB_URL}
               target="_blank"
               rel="noopener noreferrer"
-              className="flex items-center gap-2 rounded-md border border-border/50 bg-background px-3 py-2 text-sm text-foreground hover:bg-accent/50 transition-colors"
+              className="flex h-10 items-center gap-2 rounded-lg border border-border/50 bg-background px-4 text-sm text-foreground hover:bg-accent/50 transition-colors"
             >
               <Github className="h-4 w-4" />
               GitHub
@@ -614,31 +626,29 @@ export function SettingsView() {
               href={GITHUB_ISSUES_URL}
               target="_blank"
               rel="noopener noreferrer"
-              className="flex items-center gap-2 rounded-md border border-border/50 bg-background px-3 py-2 text-sm text-foreground hover:bg-accent/50 transition-colors"
+              className="flex h-10 items-center gap-2 rounded-lg border border-border/50 bg-background px-4 text-sm text-foreground hover:bg-accent/50 transition-colors"
             >
               <ExternalLink className="h-4 w-4" />
               提交 Issue
             </a>
           </div>
-          <div className="px-3 py-2.5">
-            <p className="text-xs font-medium text-foreground">数据存储目录</p>
-            <p className="mt-0.5 text-[11px] text-muted-foreground">
-              点击整行复制路径。
-            </p>
-            <div className="mt-2 overflow-hidden">
+
+          {/* Data Paths */}
+          <div>
+            <h3 className="text-sm font-semibold text-foreground">数据存储目录</h3>
+            <p className="mt-1 text-xs text-muted-foreground">点击复制对应平台的路径</p>
+            <div className="mt-3 rounded-lg border border-border/40 overflow-hidden divide-y divide-border/30">
               {DATA_PATHS.map(({ platform, path, icon: Icon }) => (
                 <button
                   key={platform}
                   type="button"
                   onClick={() => copyPath(path)}
-                  className={cn(
-                    'flex w-full items-center gap-3 px-2.5 py-2 text-left text-xs transition-colors hover:bg-accent/40 rounded-md text-muted-foreground'
-                  )}
+                  className="flex w-full items-center gap-3 px-4 py-3 text-left text-sm transition-colors hover:bg-accent/30"
                   title="点击复制路径"
                 >
                   <Icon className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden />
-                  <span className="shrink-0 w-16 font-medium">{platform}</span>
-                  <code className="min-w-0 flex-1 break-all rounded bg-muted/60 py-1 px-2 font-mono text-[11px] text-foreground/90">
+                  <span className="shrink-0 w-20 font-medium text-foreground">{platform}</span>
+                  <code className="min-w-0 flex-1 break-all font-mono text-xs text-muted-foreground">
                     {path}
                   </code>
                 </button>

--- a/frontend/src/hooks/useSettings.ts
+++ b/frontend/src/hooks/useSettings.ts
@@ -11,6 +11,7 @@ import {
 import { getSettings, updateSettings, resetSettings as apiResetSettings } from '@/api/settings'
 import type { AppSettings } from '@/api/settings'
 
+export type ThemeMode = 'system' | 'light' | 'dark'
 export type Language = 'en' | 'zh'
 export type FontSize = number
 export type Timezone = 'local' | 'utc'
@@ -20,6 +21,7 @@ export type FetchLimit = 32 | 64 | 128
 
 // 前端使用的设置接口（与后端 AppSettings 字段一致）
 export interface FrontendSettings {
+  theme: ThemeMode
   language: Language
   fontSize: FontSize
   uiFont: string
@@ -42,6 +44,7 @@ export interface FrontendSettings {
 }
 
 const DEFAULTS: FrontendSettings = {
+  theme: 'system',
   language: 'zh',
   fontSize: 14,
   uiFont: 'system',
@@ -69,6 +72,7 @@ const MAX_FONT_SIZE = 18
 // 将后端返回的 AppSettings 转为前端类型
 function toFrontend(s: AppSettings): FrontendSettings {
   return {
+    theme: (['system', 'light', 'dark'].includes(s.theme) ? s.theme : DEFAULTS.theme) as ThemeMode,
     language: (s.language as Language) || DEFAULTS.language,
     fontSize: (typeof s.fontSize === 'number' && s.fontSize >= 12 && s.fontSize <= 18) ? s.fontSize : DEFAULTS.fontSize,
     uiFont: s.uiFont || DEFAULTS.uiFont,
@@ -101,37 +105,67 @@ type SettingsContextValue = {
   setSetting: <K extends keyof FrontendSettings>(key: K, value: FrontendSettings[K]) => void
   resetAllSettings: () => Promise<void>
   loading: boolean
+  effectiveDark: boolean
 }
 
 const SettingsContext = createContext<SettingsContextValue | null>(null)
 
 const SYSTEM_FONT_STACK = '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif'
 
+function getSystemDark(): boolean {
+  if (typeof window === 'undefined') return false
+  return window.matchMedia('(prefers-color-scheme: dark)').matches
+}
+
+function applyTheme(mode: ThemeMode) {
+  const dark = mode === 'system' ? getSystemDark() : mode === 'dark'
+  document.documentElement.classList.toggle('dark', dark)
+}
+
 function applySettingsToDocument(settings: FrontendSettings) {
   const root = document.documentElement
+
+  // 主题
+  applyTheme(settings.theme)
+
+  // 字体大小
   const size = Math.max(MIN_FONT_SIZE, Math.min(MAX_FONT_SIZE, settings.fontSize))
   root.style.setProperty('--app-font-size', `${size}px`)
+
+  // UI 字体
   const uiFont = settings.uiFont.trim()
   root.style.setProperty(
     '--app-ui-font',
     !uiFont || uiFont === 'system' ? SYSTEM_FONT_STACK : `"${uiFont}", ${SYSTEM_FONT_STACK}`
   )
+
+  // 等宽字体
   root.style.setProperty('--app-monospace-font', settings.monospaceFont.trim() || DEFAULTS.monospaceFont)
+
+  // 语言
   root.lang = settings.language === 'en' ? 'en' : 'zh-CN'
 }
 
 function useSettingsStore(): SettingsContextValue {
   const [settings, setSettingsState] = useState<FrontendSettings>(DEFAULTS)
   const [loading, setLoading] = useState(true)
+  const [effectiveDark, setEffectiveDark] = useState(() => getSystemDark())
   const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
-  // 组件挂载时从后端加载设置
+  // 组件挂载时从后端加载设置，并迁移 localStorage 中的旧主题数据
   useEffect(() => {
     let cancelled = false
     getSettings()
       .then((result) => {
         if (!cancelled && result) {
-          setSettingsState(toFrontend(result))
+          const frontend = toFrontend(result)
+          // 迁移旧 localStorage 主题到后端
+          const legacyTheme = localStorage.getItem('rocket-leaf-theme')
+          if (legacyTheme && ['light', 'dark', 'system'].includes(legacyTheme) && frontend.theme === 'system') {
+            frontend.theme = legacyTheme as ThemeMode
+            localStorage.removeItem('rocket-leaf-theme')
+          }
+          setSettingsState(frontend)
         }
       })
       .catch(() => {
@@ -147,7 +181,20 @@ function useSettingsStore(): SettingsContextValue {
 
   useEffect(() => {
     applySettingsToDocument(settings)
+    setEffectiveDark(settings.theme === 'system' ? getSystemDark() : settings.theme === 'dark')
   }, [settings])
+
+  // 监听系统主题变化（仅在 theme === 'system' 时响应）
+  useEffect(() => {
+    if (settings.theme !== 'system') return
+    const mq = window.matchMedia('(prefers-color-scheme: dark)')
+    const handler = () => {
+      applyTheme('system')
+      setEffectiveDark(mq.matches)
+    }
+    mq.addEventListener('change', handler)
+    return () => mq.removeEventListener('change', handler)
+  }, [settings.theme])
 
   // 防抖保存到后端
   const saveToBackend = useCallback((newSettings: FrontendSettings) => {
@@ -181,7 +228,7 @@ function useSettingsStore(): SettingsContextValue {
     }
   }, [])
 
-  return { settings, setSetting, resetAllSettings, loading }
+  return { settings, setSetting, resetAllSettings, loading, effectiveDark }
 }
 
 export function SettingsProvider({ children }: { children: ReactNode }) {

--- a/internal/model/settings.go
+++ b/internal/model/settings.go
@@ -4,6 +4,7 @@ package model
 // AppSettings 应用设置
 type AppSettings struct {
 	// 通用设置
+	Theme           string `json:"theme"`           // 主题: "system" | "light" | "dark"
 	Language        string `json:"language"`        // 语言: "en" | "zh"
 	FontSize        int    `json:"fontSize"`        // 字体大小(px): 12-18
 	UIFont          string `json:"uiFont"`          // 界面字体
@@ -32,6 +33,7 @@ type AppSettings struct {
 // DefaultSettings 返回默认设置
 func DefaultSettings() *AppSettings {
 	return &AppSettings{
+		Theme:                "system",
 		Language:              "zh",
 		FontSize:              14,
 		UIFont:                "system",


### PR DESCRIPTION
## Summary
- Move theme (system/light/dark) from localStorage to backend AppSettings for consistent persistence across restarts
- Add `theme` field to Go AppSettings model with default "system"
- Migrate legacy localStorage theme data on first load, then remove it
- Add system media query listener to respond to OS theme changes when set to "system"
- Remove useTheme hook dependency from SettingsView, use unified settings system
- Fix GitHub URLs from codermast to amigoer