### PR TITLE
feat: add confirmation dialog for dangerous settings operations

### DIFF
--- a/frontend/src/components/SettingsView.tsx
+++ b/frontend/src/components/SettingsView.tsx
@@ -29,6 +29,7 @@ import {
   type FetchLimit,
 } from '@/hooks/useSettings'
 
+import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import logoUrl from '@/assets/logo.png'
 
 const APP_VERSION = __APP_VERSION__
@@ -192,6 +193,11 @@ function Toggle({
 export function SettingsView() {
   const [activeTab, setActiveTab] = useState<SettingsTabId>('general')
   const { settings, setSetting, resetAllSettings, loading } = useSettings()
+  const [confirmAction, setConfirmAction] = useState<{
+    title: string
+    description: string
+    onConfirm: () => void
+  } | null>(null)
 
   const copyPath = useCallback(async (path: string) => {
     try {
@@ -236,7 +242,7 @@ export function SettingsView() {
     }
     input.click()
   }, [])
-  const handleClearCache = useCallback(async () => {
+  const doClearCache = useCallback(async () => {
     try {
       const { clearCache } = await import('@/api/settings')
       await clearCache()
@@ -245,7 +251,15 @@ export function SettingsView() {
       toast.error('清理缓存失败')
     }
   }, [])
-  const handleResetSettings = useCallback(async () => {
+  const handleClearCache = useCallback(() => {
+    setConfirmAction({
+      title: '清理缓存',
+      description: '确定要清理所有缓存数据吗？此操作不可撤销。',
+      onConfirm: () => { setConfirmAction(null); doClearCache() },
+    })
+  }, [doClearCache])
+
+  const doResetSettings = useCallback(async () => {
     try {
       await resetAllSettings()
       toast.success('已恢复默认设置')
@@ -253,6 +267,13 @@ export function SettingsView() {
       toast.error('恢复默认设置失败')
     }
   }, [resetAllSettings])
+  const handleResetSettings = useCallback(() => {
+    setConfirmAction({
+      title: '恢复默认设置',
+      description: '确定要将所有设置恢复为默认值吗？当前的自定义设置将全部丢失。',
+      onConfirm: () => { setConfirmAction(null); doResetSettings() },
+    })
+  }, [doResetSettings])
   const handleCheckUpdate = useCallback(() => {
     Browser.OpenURL(GITHUB_RELEASES_URL)
       .catch(() => window.open(GITHUB_RELEASES_URL, '_blank', 'noopener,noreferrer'))
@@ -660,6 +681,17 @@ export function SettingsView() {
           </fieldset>
         </main>
       </div>
+
+      <ConfirmDialog
+        open={confirmAction !== null}
+        title={confirmAction?.title ?? ''}
+        description={confirmAction?.description ?? ''}
+        confirmText="确认"
+        cancelText="取消"
+        variant="destructive"
+        onConfirm={confirmAction?.onConfirm ?? (() => {})}
+        onCancel={() => setConfirmAction(null)}
+      />
     </div>
   )
 }

--- a/frontend/src/components/ui/confirm-dialog.tsx
+++ b/frontend/src/components/ui/confirm-dialog.tsx
@@ -1,0 +1,95 @@
+import { useCallback, useEffect, useRef } from 'react'
+import { cn } from '@/lib/utils'
+
+interface ConfirmDialogProps {
+  open: boolean
+  title: string
+  description: string
+  confirmText?: string
+  cancelText?: string
+  variant?: 'default' | 'destructive'
+  onConfirm: () => void
+  onCancel: () => void
+}
+
+export function ConfirmDialog({
+  open,
+  title,
+  description,
+  confirmText = '确认',
+  cancelText = '取消',
+  variant = 'default',
+  onConfirm,
+  onCancel,
+}: ConfirmDialogProps) {
+  const dialogRef = useRef<HTMLDivElement>(null)
+
+  // ESC 关闭
+  useEffect(() => {
+    if (!open) return
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onCancel()
+    }
+    document.addEventListener('keydown', handler)
+    return () => document.removeEventListener('keydown', handler)
+  }, [open, onCancel])
+
+  // 打开时聚焦取消按钮（安全默认）
+  useEffect(() => {
+    if (open) dialogRef.current?.querySelector<HTMLButtonElement>('[data-cancel]')?.focus()
+  }, [open])
+
+  const handleBackdropClick = useCallback(
+    (e: React.MouseEvent) => {
+      if (e.target === e.currentTarget) onCancel()
+    },
+    [onCancel]
+  )
+
+  if (!open) return null
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm"
+      onClick={handleBackdropClick}
+    >
+      <div
+        ref={dialogRef}
+        role="alertdialog"
+        aria-modal="true"
+        aria-labelledby="confirm-title"
+        aria-describedby="confirm-desc"
+        className="w-full max-w-sm rounded-xl border border-border/50 bg-background p-6 shadow-lg animate-in fade-in zoom-in-95 duration-150"
+      >
+        <h2 id="confirm-title" className="text-base font-semibold text-foreground">
+          {title}
+        </h2>
+        <p id="confirm-desc" className="mt-2 text-sm leading-relaxed text-muted-foreground">
+          {description}
+        </p>
+        <div className="mt-5 flex justify-end gap-2.5">
+          <button
+            type="button"
+            data-cancel
+            onClick={onCancel}
+            className="h-9 rounded-lg border border-border/50 bg-background px-4 text-sm text-foreground hover:bg-accent/50 transition-colors"
+          >
+            {cancelText}
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            className={cn(
+              'h-9 rounded-lg px-4 text-sm font-medium transition-colors',
+              variant === 'destructive'
+                ? 'bg-destructive text-destructive-foreground hover:bg-destructive/90'
+                : 'bg-primary text-primary-foreground hover:bg-primary/90'
+            )}
+          >
+            {confirmText}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Add reusable ConfirmDialog component with ESC close, backdrop dismiss, and destructive variant
- Wrap "clear cache" and "reset settings" with confirmation prompts to prevent accidental data loss
- Default focus on cancel button for safety