### PR TITLE
Add TAG filtering to message query

### DIFF
--- a/frontend/bindings/rocket-leaf/internal/service/messageservice.ts
+++ b/frontend/bindings/rocket-leaf/internal/service/messageservice.ts
@@ -45,8 +45,8 @@ export function QueryMessageByID(topic: string, msgID: string): $CancellableProm
 /**
  * QueryMessages 查询消息，startTime/endTime 为 Unix 毫秒时间戳，0 表示不限制
  */
-export function QueryMessages(topic: string, key: string, maxResults: number, startTime: number, endTime: number): $CancellablePromise<(model$0.MessageItem | null)[]> {
-    return $Call.ByID(1433538526, topic, key, maxResults, startTime, endTime).then(($result: any) => {
+export function QueryMessages(topic: string, key: string, tag: string, maxResults: number, startTime: number, endTime: number): $CancellablePromise<(model$0.MessageItem | null)[]> {
+    return $Call.ByID(1433538526, topic, key, tag, maxResults, startTime, endTime).then(($result: any) => {
         return $$createType5($result);
     });
 }

--- a/frontend/src/api/message.ts
+++ b/frontend/src/api/message.ts
@@ -30,7 +30,7 @@ export async function fetchLatestMessages(topic: string, limit: number): Promise
     return Array.from({ length: Math.min(limit, LATEST_MOCK_SIZE) }, (_, i) => mockMessageItem(topic, i))
   }
   try {
-    const raw = await MessageService.QueryMessages(topic, '', limit, 0, 0)
+    const raw = await MessageService.QueryMessages(topic, '', '', limit, 0, 0)
     return raw.filter((m): m is MessageItem => m != null)
   } catch (e) {
     console.error('fetchLatestMessages', e)
@@ -41,6 +41,7 @@ export async function fetchLatestMessages(topic: string, limit: number): Promise
 export interface QueryCondition {
   messageId?: string
   messageKey?: string
+  messageTag?: string
   startTimeMs?: number
   endTimeMs?: number
 }
@@ -53,7 +54,7 @@ export async function queryMessagesByCondition(
   condition: QueryCondition,
   maxResults = 32
 ): Promise<MessageItem[]> {
-  const { messageId, messageKey = '', startTimeMs = 0, endTimeMs = 0 } = condition
+  const { messageId, messageKey = '', messageTag = '', startTimeMs = 0, endTimeMs = 0 } = condition
   if (USE_MOCK) {
     await new Promise((r) => setTimeout(r, 500))
     if (messageId?.trim()) {
@@ -68,7 +69,7 @@ export async function queryMessagesByCondition(
       const one = await MessageService.QueryMessageByID(topic, messageId.trim())
       return one ? [one] : []
     }
-    const raw = await MessageService.QueryMessages(topic, messageKey.trim(), maxResults, startTimeMs, endTimeMs)
+    const raw = await MessageService.QueryMessages(topic, messageKey.trim(), messageTag.trim(), maxResults, startTimeMs, endTimeMs)
     return raw.filter((m): m is MessageItem => m != null)
   } catch (e) {
     console.error('queryMessagesByCondition', e)
@@ -79,12 +80,13 @@ export async function queryMessagesByCondition(
 export async function queryMessages(
   topic: string,
   key: string,
+  tag: string,
   maxResults: number,
   startTimeMs = 0,
   endTimeMs = 0
 ): Promise<(MessageItem | null)[]> {
   try {
-    return await MessageService.QueryMessages(topic, key, maxResults, startTimeMs, endTimeMs)
+    return await MessageService.QueryMessages(topic, key, tag, maxResults, startTimeMs, endTimeMs)
   } catch (e) {
     console.error('QueryMessages', e)
     throw e

--- a/frontend/src/components/MessageView.tsx
+++ b/frontend/src/components/MessageView.tsx
@@ -438,6 +438,7 @@ export function MessageView() {
   const [selectedTopic, setSelectedTopic] = useState('')
   const [messageId, setMessageId] = useState('')
   const [messageKey, setMessageKey] = useState('')
+  const [messageTag, setMessageTag] = useState('')
   const [startTimeInput, setStartTimeInput] = useState('')
   const [endTimeInput, setEndTimeInput] = useState('')
   const [maxResults, setMaxResults] = useState(DEFAULT_MAX_RESULTS)
@@ -524,6 +525,7 @@ export function MessageView() {
     const condition: QueryCondition = {
       messageId: messageId.trim() || undefined,
       messageKey: messageKey.trim() || undefined,
+      messageTag: messageTag.trim() || undefined,
       startTimeMs: fromDatetimeLocalInput(startTimeInput) || undefined,
       endTimeMs: fromDatetimeLocalInput(endTimeInput) || undefined,
     }
@@ -557,7 +559,7 @@ export function MessageView() {
     } finally {
       setIsLoading(false)
     }
-  }, [selectedTopic, messageId, messageKey, maxResults, startTimeInput, endTimeInput])
+  }, [selectedTopic, messageId, messageKey, messageTag, maxResults, startTimeInput, endTimeInput])
 
   const copyMessageId = useCallback((e: React.MouseEvent, id: string) => {
     e.stopPropagation()
@@ -632,8 +634,17 @@ export function MessageView() {
             value={messageKey}
             onChange={(e) => setMessageKey(e.target.value)}
             placeholder="Key"
-            className="h-8 w-40 shrink-0 rounded-md border border-border/40 bg-background px-2.5 text-xs font-mono transition-colors focus:outline-none focus:ring-1 focus:ring-ring"
+            className="h-8 w-36 shrink-0 rounded-md border border-border/40 bg-background px-2.5 text-xs font-mono transition-colors focus:outline-none focus:ring-1 focus:ring-ring"
             aria-label="Message Key"
+          />
+          <input
+            id="msg-tag"
+            type="text"
+            value={messageTag}
+            onChange={(e) => setMessageTag(e.target.value)}
+            placeholder="Tag"
+            className="h-8 w-36 shrink-0 rounded-md border border-border/40 bg-background px-2.5 text-xs font-mono transition-colors focus:outline-none focus:ring-1 focus:ring-ring"
+            aria-label="Message Tag"
           />
         </div>
         {/* 第二行：时间 + 条数 + 查询 + 发送 */}

--- a/internal/service/message_service.go
+++ b/internal/service/message_service.go
@@ -35,7 +35,7 @@ func (s *MessageService) getNextID() int {
 }
 
 // QueryMessages 查询消息，startTime/endTime 为 Unix 毫秒时间戳，0 表示不限制
-func (s *MessageService) QueryMessages(topic string, key string, maxResults int, startTime, endTime int64) ([]*model.MessageItem, error) {
+func (s *MessageService) QueryMessages(topic string, key string, tag string, maxResults int, startTime, endTime int64) ([]*model.MessageItem, error) {
 	client, err := rocketmq.GetClientManager().GetDefaultClient()
 	if err != nil {
 		return nil, fmt.Errorf("获取客户端失败: %w", err)
@@ -55,11 +55,12 @@ func (s *MessageService) QueryMessages(topic string, key string, maxResults int,
 
 	result := make([]*model.MessageItem, 0)
 	trimmedKey := strings.TrimSpace(key)
+	trimmedTag := strings.TrimSpace(tag)
 
 	// 统一使用时间范围浏览（RocketMQ 的 Key 索引查询不够可靠）
-	// 如果有 Key 过滤条件，多拉取一些消息以确保过滤后有足够结果
+	// 如果有 Key/Tag 过滤条件，多拉取一些消息以确保过滤后有足够结果
 	fetchNum := maxResults
-	if trimmedKey != "" {
+	if trimmedKey != "" || trimmedTag != "" {
 		fetchNum = maxResults * 8
 		if fetchNum < 512 {
 			fetchNum = 512
@@ -80,6 +81,13 @@ func (s *MessageService) QueryMessages(topic string, key string, maxResults int,
 			if trimmedKey != "" {
 				msgKeys, _ := msg.Properties["KEYS"]
 				if !strings.Contains(msgKeys, trimmedKey) {
+					continue
+				}
+			}
+			// 如果指定了 Tag，只保留匹配该 Tag 的消息
+			if trimmedTag != "" {
+				msgTags, _ := msg.Properties["TAGS"]
+				if !strings.Contains(msgTags, trimmedTag) {
 					continue
 				}
 			}


### PR DESCRIPTION
## Summary
- Added `tag` parameter to `QueryMessages` backend method for server-side TAG filtering
- TAG filtering uses substring match on `Properties["TAGS"]`, consistent with existing Key filtering
- When TAG or Key filter is specified, fetches 8x messages to ensure enough results after filtering
- Added Tag input field in the message query toolbar alongside the existing Key field
- Updated frontend API layer and TypeScript bindings accordingly