### PR TITLE
Add delay message support when sending

### DIFF
--- a/frontend/bindings/rocket-leaf/internal/service/messageservice.ts
+++ b/frontend/bindings/rocket-leaf/internal/service/messageservice.ts
@@ -77,10 +77,10 @@ export function ResendMessage(consumerGroup: string, clientID: string, topic: st
 }
 
 /**
- * SendMessage ��送消息到指定 Topic
+ * SendMessage 发送消息到指定 Topic，delayLevel 0 表示不延迟，1-18 对应 RocketMQ 延迟等级
  */
-export function SendMessage(topic: string, tags: string, keys: string, body: string): $CancellablePromise<string> {
-    return $Call.ByID(1221390803, topic, tags, keys, body);
+export function SendMessage(topic: string, tags: string, keys: string, body: string, delayLevel: number): $CancellablePromise<string> {
+    return $Call.ByID(1221390803, topic, tags, keys, body, delayLevel);
 }
 
 // Private type creation functions

--- a/frontend/src/api/message.ts
+++ b/frontend/src/api/message.ts
@@ -168,10 +168,11 @@ export async function sendMessage(
   topic: string,
   tags: string,
   keys: string,
-  body: string
+  body: string,
+  delayLevel = 0
 ): Promise<string> {
   try {
-    return await MessageService.SendMessage(topic, tags, keys, body)
+    return await MessageService.SendMessage(topic, tags, keys, body, delayLevel)
   } catch (e) {
     console.error('SendMessage', e)
     throw e

--- a/frontend/src/components/ConsumerGroupList.tsx
+++ b/frontend/src/components/ConsumerGroupList.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useCallback, useEffect } from 'react'
 import { toast } from 'sonner'
-import { RefreshCw, Search, X, Trash2, Loader2, AlertTriangle, BarChart3, RotateCcw, Pencil } from 'lucide-react'
+import { RefreshCw, Search, X, Trash2, Loader2, AlertTriangle, BarChart3, RotateCcw, Pencil, Skull, RotateCw, ChevronDown, Copy } from 'lucide-react'
 import { cn, formatErrorMessage } from '@/lib/utils'
 import type { ConsumerGroupItem, MessageItem } from '../../bindings/rocket-leaf/internal/model/models.js'
 import { GroupStatus, ConsumeMode } from '../../bindings/rocket-leaf/internal/model/models.js'

--- a/frontend/src/components/MessageView.tsx
+++ b/frontend/src/components/MessageView.tsx
@@ -17,6 +17,29 @@ import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from '@/componen
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 
 const DEFAULT_MAX_RESULTS = 32
+
+const DELAY_LEVEL_OPTIONS = [
+  { value: 0, label: '不延迟' },
+  { value: 1, label: '1s' },
+  { value: 2, label: '5s' },
+  { value: 3, label: '10s' },
+  { value: 4, label: '30s' },
+  { value: 5, label: '1m' },
+  { value: 6, label: '2m' },
+  { value: 7, label: '3m' },
+  { value: 8, label: '4m' },
+  { value: 9, label: '5m' },
+  { value: 10, label: '6m' },
+  { value: 11, label: '7m' },
+  { value: 12, label: '8m' },
+  { value: 13, label: '9m' },
+  { value: 14, label: '10m' },
+  { value: 15, label: '20m' },
+  { value: 16, label: '30m' },
+  { value: 17, label: '1h' },
+  { value: 18, label: '2h' },
+]
+
 const textEncoder = new TextEncoder()
 const textDecoder = new TextDecoder()
 
@@ -454,6 +477,7 @@ export function MessageView() {
   const [sendTags, setSendTags] = useState('')
   const [sendKeys, setSendKeys] = useState('')
   const [sendBody, setSendBody] = useState('')
+  const [sendDelayLevel, setSendDelayLevel] = useState(0)
   const [isSending, setIsSending] = useState(false)
   const [trackItems, setTrackItems] = useState<{ consumerGroup: string; trackType: string; consumeStatus: string; exceptionDesc: string }[]>([])
   const [trackLoading, setTrackLoading] = useState(false)
@@ -582,7 +606,7 @@ export function MessageView() {
     }
     setIsSending(true)
     try {
-      const result = await messageApi.sendMessage(t, sendTags.trim(), sendKeys.trim(), sendBody)
+      const result = await messageApi.sendMessage(t, sendTags.trim(), sendKeys.trim(), sendBody, sendDelayLevel)
       toast.success(result)
       setSendBody('')
     } catch (e) {
@@ -590,7 +614,7 @@ export function MessageView() {
     } finally {
       setIsSending(false)
     }
-  }, [sendTopic, selectedTopic, sendTags, sendKeys, sendBody])
+  }, [sendTopic, selectedTopic, sendTags, sendKeys, sendBody, sendDelayLevel])
 
   const selectedBody = selectedMessage?.body ?? ''
   const payloadPreview = getPayloadPreview(selectedBody, settings.maxPayloadRenderBytes)
@@ -761,6 +785,17 @@ export function MessageView() {
                   className="h-9 w-28 shrink-0 rounded-md border border-border/40 bg-background px-2.5 text-sm font-mono focus:outline-none focus:ring-1 focus:ring-ring"
                   aria-label="Keys"
                 />
+                <select
+                  value={sendDelayLevel}
+                  onChange={(e) => setSendDelayLevel(Number(e.target.value))}
+                  className="h-9 shrink-0 rounded-md border border-border/40 bg-background px-2.5 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
+                  aria-label="延迟等级"
+                  title="延迟等级"
+                >
+                  {DELAY_LEVEL_OPTIONS.map((o) => (
+                    <option key={o.value} value={o.value}>{o.label}</option>
+                  ))}
+                </select>
               </div>
               <textarea
                 value={sendBody}

--- a/internal/service/message_service.go
+++ b/internal/service/message_service.go
@@ -300,17 +300,17 @@ func (s *MessageService) ResendMessage(consumerGroup string, clientID string, to
 // QueryDLQMessages 查询消费者组的死信队列消息
 func (s *MessageService) QueryDLQMessages(groupName string, maxResults int) ([]*model.MessageItem, error) {
 	dlqTopic := "%DLQ%" + groupName
-	return s.QueryMessages(dlqTopic, "", maxResults, 0, 0)
+	return s.QueryMessages(dlqTopic, "", "", maxResults, 0, 0)
 }
 
 // QueryRetryMessages 查询消费者组的重试队列消息
 func (s *MessageService) QueryRetryMessages(groupName string, maxResults int) ([]*model.MessageItem, error) {
 	retryTopic := "%RETRY%" + groupName
-	return s.QueryMessages(retryTopic, "", maxResults, 0, 0)
+	return s.QueryMessages(retryTopic, "", "", maxResults, 0, 0)
 }
 
-// SendMessage ��送消息到指定 Topic
-func (s *MessageService) SendMessage(topic string, tags string, keys string, body string) (string, error) {
+// SendMessage 发送消息到指定 Topic，delayLevel 0 表示不延迟，1-18 对应 RocketMQ 延迟等级
+func (s *MessageService) SendMessage(topic string, tags string, keys string, body string, delayLevel int) (string, error) {
 	topic = strings.TrimSpace(topic)
 	if topic == "" {
 		return "", fmt.Errorf("发送消息失败: Topic 不能为空")
@@ -350,6 +350,9 @@ func (s *MessageService) SendMessage(topic string, tags string, keys string, bod
 	}
 	if keys != "" {
 		msg.WithKeys([]string{keys})
+	}
+	if delayLevel > 0 {
+		msg.WithDelayTimeLevel(delayLevel)
 	}
 
 	result, err := p.SendSync(context.Background(), msg)


### PR DESCRIPTION
## Summary
- Added `delayLevel` parameter to `SendMessage` backend method, supporting RocketMQ delay levels 1-18 (1s, 5s, 10s, 30s, 1m ... 2h)
- Send message modal now includes a delay level dropdown with all 18 standard RocketMQ delay levels
- Default is "不延迟" (no delay), fully backward compatible
- Updated frontend API layer and TypeScript bindings