### PR TITLE
Add consumer lag alert threshold

### DIFF
--- a/frontend/bindings/rocket-leaf/internal/model/models.ts
+++ b/frontend/bindings/rocket-leaf/internal/model/models.ts
@@ -87,6 +87,12 @@ export class AppSettings {
     "proxyPort": string;
 
     /**
+     * 监控与告警
+     * 消费积压告警阈值(0=关闭)
+     */
+    "lagAlertThreshold": number;
+
+    /**
      * 消息与显示
      * 时区: "local" | "utc"
      */
@@ -158,6 +164,9 @@ export class AppSettings {
         }
         if (!("proxyPort" in $$source)) {
             this["proxyPort"] = "";
+        }
+        if (!("lagAlertThreshold" in $$source)) {
+            this["lagAlertThreshold"] = 0;
         }
         if (!("timezone" in $$source)) {
             this["timezone"] = "";

--- a/frontend/src/components/ConsumerGroupList.tsx
+++ b/frontend/src/components/ConsumerGroupList.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useCallback, useEffect } from 'react'
 import { toast } from 'sonner'
 import { RefreshCw, Search, X, Trash2, Loader2, AlertTriangle, BarChart3, RotateCcw, Pencil, Skull, RotateCw, ChevronDown, Copy, Plus } from 'lucide-react'
 import { cn, formatErrorMessage } from '@/lib/utils'
+import { useSettings } from '@/hooks/useSettings'
 import type { ConsumerGroupItem, MessageItem } from '../../bindings/rocket-leaf/internal/model/models.js'
 import { GroupStatus, ConsumeMode } from '../../bindings/rocket-leaf/internal/model/models.js'
 
@@ -86,6 +87,8 @@ function MessageCard({ msg }: { msg: MessageItem }) {
 }
 
 export function ConsumerGroupList({ list, loading, error, onRefresh }: Props) {
+  const { settings } = useSettings()
+  const lagThreshold = settings.lagAlertThreshold ?? 0
   const [searchQuery, setSearchQuery] = useState('')
   const [showTooltip, setShowTooltip] = useState(false)
   const [refreshing, setRefreshing] = useState(false)
@@ -484,7 +487,13 @@ export function ConsumerGroupList({ list, loading, error, onRefresh }: Props) {
                       <span>{consumeModeLabel(g.consumeMode)}</span>
                       <span>在线 {g.onlineClients ?? 0}</span>
                       <span>Topic {g.topicCount ?? 0}</span>
-                      {(g.lag ?? 0) > 0 && <span>堆积 {g.lag}</span>}
+                      {(g.lag ?? 0) > 0 && (
+                        <span className={cn(
+                          lagThreshold > 0 && (g.lag ?? 0) >= lagThreshold && 'text-destructive font-medium'
+                        )}>
+                          {lagThreshold > 0 && (g.lag ?? 0) >= lagThreshold && '⚠ '}堆积 {g.lag}
+                        </span>
+                      )}
                     </div>
                   </div>
                   <button
@@ -566,9 +575,22 @@ export function ConsumerGroupList({ list, loading, error, onRefresh }: Props) {
                           <div className="text-[11px] text-muted-foreground">消费 TPS</div>
                           <div className="mt-1 text-sm font-medium text-foreground">{stats?.consumeTps ?? 0}</div>
                         </div>
-                        <div className="rounded-md border border-border/40 bg-card px-3 py-2">
-                          <div className="text-[11px] text-muted-foreground">总堆积</div>
-                          <div className="mt-1 text-sm font-medium text-foreground">{stats?.diffTotal ?? 0}</div>
+                        <div className={cn(
+                          'rounded-md border px-3 py-2',
+                          lagThreshold > 0 && (stats?.diffTotal ?? 0) >= lagThreshold
+                            ? 'border-destructive/50 bg-destructive/5'
+                            : 'border-border/40 bg-card'
+                        )}>
+                          <div className="flex items-center gap-1 text-[11px] text-muted-foreground">
+                            总堆积
+                            {lagThreshold > 0 && (stats?.diffTotal ?? 0) >= lagThreshold && (
+                              <AlertTriangle className="h-3 w-3 text-destructive" />
+                            )}
+                          </div>
+                          <div className={cn(
+                            'mt-1 text-sm font-medium',
+                            lagThreshold > 0 && (stats?.diffTotal ?? 0) >= lagThreshold ? 'text-destructive' : 'text-foreground'
+                          )}>{stats?.diffTotal ?? 0}</div>
                         </div>
                       </div>
                     )}

--- a/frontend/src/components/SettingsView.tsx
+++ b/frontend/src/components/SettingsView.tsx
@@ -577,6 +577,18 @@ export function SettingsView() {
               className="w-20 h-10 rounded-md border border-border/50 bg-background px-3 text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-border"
             />
           </Row>
+          <Row label="消费积压告警阈值" hint="当消费组堆积消息超过此值时显示告警，设为 0 关闭">
+            <input
+              type="number"
+              min={0}
+              step={1000}
+              value={settings.lagAlertThreshold ?? 0}
+              onChange={(e) => setSetting('lagAlertThreshold', Number(e.target.value) || 0)}
+              title="积压告警阈值"
+              aria-label="积压告警阈值"
+              className="w-24 h-10 rounded-md border border-border/50 bg-background px-3 text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-border"
+            />
+          </Row>
           <Row label="单页拉取数量" hint="每次查询 Topic、消费组的数量上限">
             <select
               value={settings.fetchLimit}

--- a/frontend/src/hooks/useSettings.ts
+++ b/frontend/src/hooks/useSettings.ts
@@ -39,6 +39,7 @@ export interface FrontendSettings {
   timezone: Timezone
   timestampFormat: TimestampFormat
   autoFormatJson: boolean
+  lagAlertThreshold: number
   maxPayloadRenderBytes: number
   fetchLimit: FetchLimit
 }
@@ -59,6 +60,7 @@ const DEFAULTS: FrontendSettings = {
   proxyType: 'http',
   proxyHost: '',
   proxyPort: '',
+  lagAlertThreshold: 10000,
   timezone: 'local',
   timestampFormat: 'datetime',
   autoFormatJson: true,
@@ -87,6 +89,7 @@ function toFrontend(s: AppSettings): FrontendSettings {
     proxyType: (s.proxyType as ProxyType) || DEFAULTS.proxyType,
     proxyHost: s.proxyHost ?? '',
     proxyPort: s.proxyPort ?? '',
+    lagAlertThreshold: typeof s.lagAlertThreshold === 'number' ? s.lagAlertThreshold : DEFAULTS.lagAlertThreshold,
     timezone: (s.timezone as Timezone) || DEFAULTS.timezone,
     timestampFormat: (s.timestampFormat as TimestampFormat) || DEFAULTS.timestampFormat,
     autoFormatJson: s.autoFormatJson ?? DEFAULTS.autoFormatJson,

--- a/internal/model/settings.go
+++ b/internal/model/settings.go
@@ -22,6 +22,9 @@ type AppSettings struct {
 	ProxyHost       string `json:"proxyHost"`        // 代理地址
 	ProxyPort       string `json:"proxyPort"`        // 代理端口
 
+	// 监控与告警
+	LagAlertThreshold int `json:"lagAlertThreshold"` // 消费积压告警阈值(0=关闭)
+
 	// 消息与显示
 	Timezone              string `json:"timezone"`              // 时区: "local" | "utc"
 	TimestampFormat       string `json:"timestampFormat"`       // 时间戳格式: "datetime" | "ms"
@@ -48,6 +51,7 @@ func DefaultSettings() *AppSettings {
 		ProxyType:             "http",
 		ProxyHost:             "",
 		ProxyPort:             "",
+		LagAlertThreshold:     10000,
 		Timezone:              "local",
 		TimestampFormat:       "datetime",
 		AutoFormatJson:        true,


### PR DESCRIPTION
## Summary
- Add `lagAlertThreshold` field to settings model (default: 10000, set to 0 to disable)
- Settings UI: new input field in "消息与显示" tab for configuring the threshold
- Consumer group detail: stats "总堆积" card turns red with AlertTriangle icon when lag >= threshold
- Consumer group list: lag text shows warning styling when exceeding threshold
- Full-stack: backend model, Wails bindings, frontend settings hook, and UI components all updated