### PR TITLE
feat: system topic browser for transaction/scheduled messages

### DIFF
--- a/frontend/bindings/rocket-leaf/internal/service/topicservice.ts
+++ b/frontend/bindings/rocket-leaf/internal/service/topicservice.ts
@@ -29,6 +29,15 @@ export function DeleteTopic(topic: string, clusterName: string): $CancellablePro
 }
 
 /**
+ * GetAllTopics 获取所有 Topic 列表（含系统 Topic）
+ */
+export function GetAllTopics(): $CancellablePromise<(model$0.TopicItem | null)[]> {
+    return $Call.ByID(2226136997).then(($result: any) => {
+        return $$createType2($result);
+    });
+}
+
+/**
  * GetTopicDetail 获取 Topic 详情
  */
 export function GetTopicDetail(topicName: string): $CancellablePromise<model$0.TopicItem | null> {
@@ -42,7 +51,7 @@ export function GetTopicDetail(topicName: string): $CancellablePromise<model$0.T
  */
 export function GetTopicRoute(topicName: string): $CancellablePromise<model$0.TopicRouteItem[]> {
     return $Call.ByID(72765298, topicName).then(($result: any) => {
-        return $$createType3($result);
+        return $$createType4($result);
     });
 }
 
@@ -51,7 +60,7 @@ export function GetTopicRoute(topicName: string): $CancellablePromise<model$0.To
  */
 export function GetTopicStats(topic: string): $CancellablePromise<{ [_ in string]?: any }> {
     return $Call.ByID(3741851472, topic).then(($result: any) => {
-        return $$createType4($result);
+        return $$createType5($result);
     });
 }
 
@@ -67,7 +76,7 @@ export function GetTopicTotal(): $CancellablePromise<number> {
  */
 export function GetTopics(): $CancellablePromise<(model$0.TopicItem | null)[]> {
     return $Call.ByID(2552409270).then(($result: any) => {
-        return $$createType5($result);
+        return $$createType2($result);
     });
 }
 
@@ -76,7 +85,7 @@ export function GetTopics(): $CancellablePromise<(model$0.TopicItem | null)[]> {
  */
 export function GetTopicsByCluster(clusterName: string): $CancellablePromise<(model$0.TopicItem | null)[]> {
     return $Call.ByID(3041396751, clusterName).then(($result: any) => {
-        return $$createType5($result);
+        return $$createType2($result);
     });
 }
 
@@ -90,7 +99,7 @@ export function UpdateTopic(topic: string, brokerAddr: string, readQueue: number
 // Private type creation functions
 const $$createType0 = model$0.TopicItem.createFrom;
 const $$createType1 = $Create.Nullable($$createType0);
-const $$createType2 = model$0.TopicRouteItem.createFrom;
-const $$createType3 = $Create.Array($$createType2);
-const $$createType4 = $Create.Map($Create.Any, $Create.Any);
-const $$createType5 = $Create.Array($$createType1);
+const $$createType2 = $Create.Array($$createType1);
+const $$createType3 = model$0.TopicRouteItem.createFrom;
+const $$createType4 = $Create.Array($$createType3);
+const $$createType5 = $Create.Map($Create.Any, $Create.Any);

--- a/frontend/src/api/topic.ts
+++ b/frontend/src/api/topic.ts
@@ -10,6 +10,15 @@ export async function getTopics(): Promise<(TopicItem | null)[]> {
   }
 }
 
+export async function getAllTopics(): Promise<(TopicItem | null)[]> {
+  try {
+    return await TopicService.GetAllTopics()
+  } catch (e) {
+    console.error('GetAllTopics', e)
+    throw e
+  }
+}
+
 export async function getTopicDetail(topicName: string): Promise<TopicItem | null> {
   try {
     return await TopicService.GetTopicDetail(topicName)

--- a/frontend/src/components/TopicList.tsx
+++ b/frontend/src/components/TopicList.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useCallback, useEffect } from 'react'
 import { toast } from 'sonner'
-import { RefreshCw, Plus, Search, X, Trash2, Loader2, AlertTriangle, BarChart3, Pencil, ChevronDown, Filter } from 'lucide-react'
+import { RefreshCw, Plus, Search, X, Trash2, Loader2, AlertTriangle, BarChart3, Pencil, ChevronDown, Filter, Eye, EyeOff } from 'lucide-react'
 import { cn, formatErrorMessage } from '@/lib/utils'
 import type { TopicItem } from '../../bindings/rocket-leaf/internal/model/models.js'
 import { TopicPerm } from '../../bindings/rocket-leaf/internal/model/models.js'
@@ -68,6 +68,9 @@ const PERM_OPTIONS: { value: TopicPerm; label: string }[] = [
 export function TopicList({ list, loading, error, onRefresh }: Props) {
   const [searchQuery, setSearchQuery] = useState('')
   const [clusterFilter, setClusterFilter] = useState<string>('')
+  const [showSystem, setShowSystem] = useState(false)
+  const [systemTopics, setSystemTopics] = useState<TopicItem[]>([])
+  const [systemLoading, setSystemLoading] = useState(false)
   const [showTooltip, setShowTooltip] = useState(false)
   const [refreshing, setRefreshing] = useState(false)
   const [selectedTopic, setSelectedTopic] = useState<string | null>(null)
@@ -95,9 +98,28 @@ export function TopicList({ list, loading, error, onRefresh }: Props) {
 
   const isSpinning = loading || refreshing
 
-  const clusterNames = Array.from(new Set(list.map((t) => t.cluster ?? '').filter(Boolean))).sort()
+  // 切换系统 Topic 时加载
+  useEffect(() => {
+    if (!showSystem) { setSystemTopics([]); return }
+    let cancelled = false
+    setSystemLoading(true)
+    topicApi.getAllTopics()
+      .then((data) => {
+        if (cancelled) return
+        const all = data.filter((t): t is TopicItem => t != null)
+        // 仅保留系统 Topic（不在 list 中的）
+        const userTopicSet = new Set(list.map((t) => t.topic ?? ''))
+        setSystemTopics(all.filter((t) => !userTopicSet.has(t.topic ?? '')))
+      })
+      .catch(() => { if (!cancelled) setSystemTopics([]) })
+      .finally(() => { if (!cancelled) setSystemLoading(false) })
+    return () => { cancelled = true }
+  }, [showSystem, list])
 
-  const filteredList = list.filter((t) => {
+  const combinedList = showSystem ? [...list, ...systemTopics] : list
+  const clusterNames = Array.from(new Set(combinedList.map((t) => t.cluster ?? '').filter(Boolean))).sort()
+
+  const filteredList = combinedList.filter((t) => {
     if (clusterFilter && (t.cluster ?? '') !== clusterFilter) return false
     if (searchQuery.trim() && !(t.topic ?? '').toLowerCase().includes(searchQuery.trim().toLowerCase())) return false
     return true
@@ -297,6 +319,18 @@ export function TopicList({ list, loading, error, onRefresh }: Props) {
           <div className="flex items-center gap-1">
             <button
               type="button"
+              onClick={() => setShowSystem(!showSystem)}
+              className={cn(
+                'flex h-8 w-8 items-center justify-center rounded-md transition-colors',
+                showSystem ? 'bg-primary/10 text-primary' : 'text-muted-foreground hover:bg-accent hover:text-foreground'
+              )}
+              aria-label={showSystem ? '隐藏系统 Topic' : '显示系统 Topic'}
+              title={showSystem ? '隐藏系统 Topic' : '显示系统 Topic'}
+            >
+              {systemLoading ? <Loader2 className="h-4 w-4 animate-spin" /> : showSystem ? <Eye className="h-4 w-4" /> : <EyeOff className="h-4 w-4" />}
+            </button>
+            <button
+              type="button"
               onClick={() => {
                 setCreateError(null)
                 setCreateOpen(true)
@@ -389,7 +423,12 @@ export function TopicList({ list, loading, error, onRefresh }: Props) {
                   )}
                 >
                   <div className="min-w-0 flex-1">
-                    <span className="text-sm font-medium text-foreground">{t.topic}</span>
+                    <div className="flex items-center gap-1.5">
+                      <span className="text-sm font-medium text-foreground truncate">{t.topic}</span>
+                      {(t.description === '系统') && (
+                        <span className="shrink-0 rounded bg-amber-500/10 px-1 py-0.5 text-[10px] font-medium text-amber-700 dark:text-amber-400">系统</span>
+                      )}
+                    </div>
                     {(t.readQueue ?? -1) >= 0 && (t.writeQueue ?? -1) >= 0 ? (
                       <span className="ml-2 text-xs text-muted-foreground">
                         读 {t.readQueue} / 写 {t.writeQueue}

--- a/internal/service/topic_service.go
+++ b/internal/service/topic_service.go
@@ -76,6 +76,48 @@ func (s *TopicService) GetTopics() ([]*model.TopicItem, error) {
 	return result, nil
 }
 
+// GetAllTopics 获取所有 Topic 列表（含系统 Topic）
+func (s *TopicService) GetAllTopics() ([]*model.TopicItem, error) {
+	client, err := rocketmq.GetClientManager().GetDefaultClient()
+	if err != nil {
+		return []*model.TopicItem{}, nil
+	}
+
+	result := make([]*model.TopicItem, 0)
+	err = executeWithClientRetry(client, func(retryClient *admin.Client) error {
+		ctx, cancel := context.WithTimeout(context.Background(), s.settingsService.GetRequestTimeout())
+		defer cancel()
+
+		topicList, callErr := retryClient.FetchAllTopicList(ctx)
+		if callErr != nil {
+			return callErr
+		}
+
+		tmpResult := make([]*model.TopicItem, 0, len(topicList.TopicList))
+		for _, topic := range topicList.TopicList {
+			item := &model.TopicItem{
+				ID:          s.getNextID(),
+				Topic:       topic,
+				ReadQueue:   -1,
+				WriteQueue:  -1,
+				LastUpdated: formatNow(),
+			}
+			if isSystemTopic(topic) {
+				item.Description = "系统"
+			}
+			tmpResult = append(tmpResult, item)
+		}
+
+		result = tmpResult
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("获取 Topic 列表失败: %w", err)
+	}
+
+	return result, nil
+}
+
 // GetTopicTotal 获取 Topic 总数（排除系统 Topic）
 func (s *TopicService) GetTopicTotal() (int, error) {
 	client, err := rocketmq.GetClientManager().GetDefaultClient()


### PR DESCRIPTION
## Summary
- Add `GetAllTopics()` backend method that returns all topics including system ones, with system topics marked by Description "系统"
- Add system topic toggle button (Eye/EyeOff icon) in TopicList header with loading spinner
- System topics displayed with amber "系统" badge and merged into the filtered list alongside regular topics
- Enables browsing `SCHEDULE_TOPIC_XXXX` (delayed messages), `RMQ_SYS_TRANS_HALF_TOPIC` (transaction half messages), and other internal system topics