### PR TITLE
feat(producer): keep last sent content per topic

### DIFF
--- a/desktop/src/renderer/i18n/locales/en.json
+++ b/desktop/src/renderer/i18n/locales/en.json
@@ -522,6 +522,8 @@
     "send": "Send",
     "sending": "Sending…",
     "reset": "Reset",
+    "resetTitle": "Clear the form and delete this topic's saved content",
+    "draftRestored": "The last message sent to this topic is saved",
     "history": "Recent sends",
     "historyHint": "Kept only for this session",
     "historyEmpty": "No sends yet",

--- a/desktop/src/renderer/i18n/locales/zh.json
+++ b/desktop/src/renderer/i18n/locales/zh.json
@@ -522,6 +522,8 @@
     "send": "发送",
     "sending": "发送中…",
     "reset": "重置",
+    "resetTitle": "清空表单，并删除该 Topic 已保存的内容",
+    "draftRestored": "已保存该 Topic 上次发送的内容",
     "history": "最近发送",
     "historyHint": "仅本会话保留",
     "historyEmpty": "暂无发送记录",

--- a/desktop/src/renderer/lib/producerDrafts.test.ts
+++ b/desktop/src/renderer/lib/producerDrafts.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  clearProducerDraft,
+  loadProducerScope,
+  saveProducerDraft,
+  type ProducerDraft,
+} from './producerDrafts'
+
+const KEY = 'rocket-leaf:producer-drafts'
+
+function draft(overrides: Partial<ProducerDraft> = {}): ProducerDraft {
+  return { tag: 'order.create', key: 'ORD-1', delay: 3, body: '{"a":1}', ...overrides }
+}
+
+describe('producerDrafts storage', () => {
+  const store = new Map<string, string>()
+
+  beforeEach(() => {
+    store.clear()
+    vi.stubGlobal('window', globalThis)
+    vi.stubGlobal('localStorage', {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => {
+        store.set(k, v)
+      },
+      removeItem: (k: string) => {
+        store.delete(k)
+      },
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('returns an empty scope when nothing is stored', () => {
+    expect(loadProducerScope('c1:localhost:9876')).toEqual({ lastTopic: '', drafts: {} })
+  })
+
+  it('round-trips a draft and marks the topic as last used', () => {
+    saveProducerDraft('c1', 'TopicA', draft())
+    const scope = loadProducerScope('c1')
+    expect(scope.lastTopic).toBe('TopicA')
+    expect(scope.drafts.TopicA).toEqual(draft())
+    expect(store.get(KEY)).toBeTruthy()
+  })
+
+  it('keeps each topic separate and moves lastTopic to the newest send', () => {
+    saveProducerDraft('c1', 'TopicA', draft({ body: 'A' }))
+    saveProducerDraft('c1', 'TopicB', draft({ body: 'B' }))
+    const scope = loadProducerScope('c1')
+    expect(scope.lastTopic).toBe('TopicB')
+    expect(scope.drafts.TopicA?.body).toBe('A')
+    expect(scope.drafts.TopicB?.body).toBe('B')
+  })
+
+  it('does not leak drafts across connections', () => {
+    saveProducerDraft('c1', 'TopicA', draft({ body: 'from c1' }))
+    saveProducerDraft('c2', 'TopicA', draft({ body: 'from c2' }))
+    expect(loadProducerScope('c1').drafts.TopicA?.body).toBe('from c1')
+    expect(loadProducerScope('c2').drafts.TopicA?.body).toBe('from c2')
+  })
+
+  it('ignores an empty topic', () => {
+    saveProducerDraft('c1', '', draft())
+    expect(loadProducerScope('c1')).toEqual({ lastTopic: '', drafts: {} })
+  })
+
+  it('clears only the target topic and leaves lastTopic alone', () => {
+    saveProducerDraft('c1', 'TopicA', draft({ body: 'A' }))
+    saveProducerDraft('c1', 'TopicB', draft({ body: 'B' }))
+    const scope = clearProducerDraft('c1', 'TopicB')
+    expect(scope.drafts.TopicB).toBeUndefined()
+    expect(scope.drafts.TopicA?.body).toBe('A')
+    expect(scope.lastTopic).toBe('TopicB')
+    expect(loadProducerScope('c1').drafts.TopicB).toBeUndefined()
+  })
+
+  it('clearing an unknown topic is a no-op', () => {
+    saveProducerDraft('c1', 'TopicA', draft())
+    expect(clearProducerDraft('c1', 'Nope').drafts.TopicA).toBeDefined()
+    expect(clearProducerDraft('missing-scope', 'TopicA')).toEqual({ lastTopic: '', drafts: {} })
+  })
+
+  it('evicts the least recently saved topics past the cap', () => {
+    let now = 1_000
+    vi.spyOn(Date, 'now').mockImplementation(() => (now += 1_000))
+    for (let i = 0; i < 33; i += 1) {
+      saveProducerDraft('c1', `Topic${i}`, draft({ body: String(i) }))
+    }
+    const scope = loadProducerScope('c1')
+    expect(Object.keys(scope.drafts)).toHaveLength(30)
+    expect(scope.drafts.Topic0).toBeUndefined()
+    expect(scope.drafts.Topic2).toBeUndefined()
+    expect(scope.drafts.Topic3).toBeDefined()
+    expect(scope.drafts.Topic32).toBeDefined()
+  })
+
+  it('evicts the least recently used connections past the cap', () => {
+    let now = 1_000
+    vi.spyOn(Date, 'now').mockImplementation(() => (now += 1_000))
+    for (let i = 0; i < 12; i += 1) {
+      saveProducerDraft(`c${i}`, 'TopicA', draft())
+    }
+    expect(loadProducerScope('c0').drafts.TopicA).toBeUndefined()
+    expect(loadProducerScope('c1').drafts.TopicA).toBeUndefined()
+    expect(loadProducerScope('c2').drafts.TopicA).toBeDefined()
+    expect(loadProducerScope('c11').drafts.TopicA).toBeDefined()
+  })
+
+  it('skips an oversized body and keeps the previous content', () => {
+    saveProducerDraft('c1', 'TopicA', draft({ body: 'small' }))
+    const scope = saveProducerDraft('c1', 'TopicA', draft({ body: 'x'.repeat(256 * 1024 + 1) }))
+    expect(scope.drafts.TopicA?.body).toBe('small')
+    expect(scope.lastTopic).toBe('TopicA')
+  })
+
+  it('clamps the delay level on write and on read', () => {
+    saveProducerDraft('c1', 'TopicA', draft({ delay: 99 }))
+    expect(loadProducerScope('c1').drafts.TopicA?.delay).toBe(18)
+    const stored = { c2: { lastTopic: 'T', drafts: { T: { ...draft(), delay: -5 } } } }
+    store.set(KEY, JSON.stringify(stored))
+    expect(loadProducerScope('c2').drafts.T?.delay).toBe(0)
+  })
+
+  it('falls back to an empty scope on corrupt or mistyped data', () => {
+    store.set(KEY, 'not json')
+    expect(loadProducerScope('c1')).toEqual({ lastTopic: '', drafts: {} })
+
+    store.set(KEY, JSON.stringify({ c1: { lastTopic: 7, drafts: { T: { tag: 1 }, U: null } } }))
+    expect(loadProducerScope('c1')).toEqual({ lastTopic: '', drafts: {} })
+  })
+})

--- a/desktop/src/renderer/lib/producerDrafts.ts
+++ b/desktop/src/renderer/lib/producerDrafts.ts
@@ -1,0 +1,170 @@
+/** The message content last sent to one topic, minus the topic itself (it is the map key). */
+export interface ProducerDraft {
+  tag: string
+  key: string
+  delay: number
+  body: string
+}
+
+/** Everything remembered for a single connection. */
+export interface ProducerScope {
+  lastTopic: string
+  drafts: Record<string, ProducerDraft>
+}
+
+const STORAGE_KEY = 'rocket-leaf:producer-drafts'
+
+/** Bodies past this size are not the kind anyone retypes, and localStorage only has ~5 MB total. */
+const MAX_BODY_BYTES = 256 * 1024
+const MAX_TOPICS_PER_SCOPE = 30
+const MAX_SCOPES = 10
+const MAX_DELAY_LEVEL = 18
+
+/** `savedAt` drives LRU eviction only, so it stays out of the public shape. */
+interface StoredDraft extends ProducerDraft {
+  savedAt: number
+}
+
+interface StoredScope {
+  lastTopic: string
+  drafts: Record<string, StoredDraft>
+}
+
+type StoredFile = Record<string, StoredScope>
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function clampDelay(value: unknown): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return 0
+  return Math.min(Math.max(Math.trunc(value), 0), MAX_DELAY_LEVEL)
+}
+
+function bodyBytes(body: string): number {
+  return new TextEncoder().encode(body).length
+}
+
+function sanitizeDraft(value: unknown): StoredDraft | null {
+  if (!isRecord(value)) return null
+  const { tag, key, body, savedAt } = value
+  if (typeof tag !== 'string' || typeof key !== 'string' || typeof body !== 'string') return null
+  return {
+    tag,
+    key,
+    body,
+    delay: clampDelay(value.delay),
+    savedAt: typeof savedAt === 'number' && Number.isFinite(savedAt) ? savedAt : 0,
+  }
+}
+
+function sanitizeScope(value: unknown): StoredScope | null {
+  if (!isRecord(value)) return null
+  const drafts: Record<string, StoredDraft> = {}
+  if (isRecord(value.drafts)) {
+    for (const [topic, raw] of Object.entries(value.drafts)) {
+      const draft = sanitizeDraft(raw)
+      if (draft) drafts[topic] = draft
+    }
+  }
+  return {
+    lastTopic: typeof value.lastTopic === 'string' ? value.lastTopic : '',
+    drafts,
+  }
+}
+
+function readFile(): StoredFile {
+  if (typeof window === 'undefined') return {}
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (!raw) return {}
+    const parsed: unknown = JSON.parse(raw)
+    if (!isRecord(parsed)) return {}
+    const file: StoredFile = {}
+    for (const [scopeKey, value] of Object.entries(parsed)) {
+      const scope = sanitizeScope(value)
+      if (scope) file[scopeKey] = scope
+    }
+    return file
+  } catch {
+    return {}
+  }
+}
+
+function newestSavedAt(scope: StoredScope): number {
+  return Object.values(scope.drafts).reduce((max, draft) => Math.max(max, draft.savedAt), 0)
+}
+
+/** Drops the least recently saved entries so the store stays bounded. Mutates `file`. */
+function trim(file: StoredFile): StoredFile {
+  for (const scope of Object.values(file)) {
+    const entries = Object.entries(scope.drafts)
+    if (entries.length <= MAX_TOPICS_PER_SCOPE) continue
+    entries.sort((a, b) => b[1].savedAt - a[1].savedAt)
+    scope.drafts = Object.fromEntries(entries.slice(0, MAX_TOPICS_PER_SCOPE))
+  }
+  const scopes = Object.entries(file)
+  if (scopes.length <= MAX_SCOPES) return file
+  scopes.sort((a, b) => newestSavedAt(b[1]) - newestSavedAt(a[1]))
+  return Object.fromEntries(scopes.slice(0, MAX_SCOPES))
+}
+
+function writeFile(file: StoredFile): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(file))
+  } catch {
+    // ignore quota / private mode
+  }
+}
+
+function toScope(stored: StoredScope | undefined): ProducerScope {
+  if (!stored) return { lastTopic: '', drafts: {} }
+  const drafts: Record<string, ProducerDraft> = {}
+  for (const [topic, draft] of Object.entries(stored.drafts)) {
+    drafts[topic] = { tag: draft.tag, key: draft.key, delay: draft.delay, body: draft.body }
+  }
+  return { lastTopic: stored.lastTopic, drafts }
+}
+
+/** Reads everything remembered for one connection. */
+export function loadProducerScope(scopeKey: string): ProducerScope {
+  return toScope(readFile()[scopeKey])
+}
+
+/**
+ * Records what was just sent to `topic` and marks it as the topic to reopen on.
+ * An oversized body is skipped rather than truncated — half a JSON payload is worse than none.
+ */
+export function saveProducerDraft(
+  scopeKey: string,
+  topic: string,
+  draft: ProducerDraft,
+): ProducerScope {
+  if (!topic) return loadProducerScope(scopeKey)
+  const file = readFile()
+  const scope = file[scopeKey] ?? { lastTopic: '', drafts: {} }
+  scope.lastTopic = topic
+  if (bodyBytes(draft.body) <= MAX_BODY_BYTES) {
+    scope.drafts[topic] = {
+      tag: draft.tag,
+      key: draft.key,
+      delay: clampDelay(draft.delay),
+      body: draft.body,
+      savedAt: Date.now(),
+    }
+  }
+  file[scopeKey] = scope
+  const trimmed = trim(file)
+  writeFile(trimmed)
+  return toScope(trimmed[scopeKey])
+}
+
+/** Forgets one topic's content. `lastTopic` is left alone so the form keeps its selection. */
+export function clearProducerDraft(scopeKey: string, topic: string): ProducerScope {
+  const file = readFile()
+  const scope = file[scopeKey]
+  if (!scope || !(topic in scope.drafts)) return toScope(scope)
+  delete scope.drafts[topic]
+  writeFile(file)
+  return toScope(scope)
+}

--- a/desktop/src/renderer/pages/ProducerPage.tsx
+++ b/desktop/src/renderer/pages/ProducerPage.tsx
@@ -1,12 +1,14 @@
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { Send, RotateCcw, X, Check, AlertCircle } from 'lucide-react'
 import { Spinner } from '@/components/Spinner'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
 import { PageHeader } from '@/components/PageHeader'
 import { PageBody } from '@/components/PageLayout'
+import { useConnections } from '@/hooks/useConnections'
 import { useTopics } from '@/hooks/useTopics'
 import * as messageApi from '@/api/message'
+import { clearProducerDraft, loadProducerScope, saveProducerDraft } from '@/lib/producerDrafts'
 import { formatErrorMessage } from '@/lib/utils'
 import { EmptyState } from '@/components/EmptyState'
 import { OfflineEmpty } from '@/components/OfflineEmpty'
@@ -51,6 +53,7 @@ function formatTime(d: Date): string {
 export function ProducerPage({ onNavigate }: { onNavigate?: (id: NavId) => void }) {
   const { t } = useTranslation()
   const { topics, hasOnline } = useTopics()
+  const { activeKey } = useConnections()
 
   const [topic, setTopic] = useState<string>('')
   const [tag, setTag] = useState('')
@@ -59,6 +62,8 @@ export function ProducerPage({ onNavigate }: { onNavigate?: (id: NavId) => void 
   const [body, setBody] = useState('')
   const [busy, setBusy] = useState(false)
   const [history, setHistory] = useState<HistoryEntry[]>([])
+  const [scope, setScope] = useState(() => loadProducerScope(activeKey))
+  const restoredKeyRef = useRef<string | null>(null)
 
   const sendableTopics = useMemo(
     () =>
@@ -68,6 +73,41 @@ export function ProducerPage({ onNavigate }: { onNavigate?: (id: NavId) => void 
         .sort(),
     [topics],
   )
+
+  // Restore the last topic sent to on this connection, once per connection. Waits for the topic
+  // list so a topic that no longer exists on the cluster is never forced into the select.
+  // The page unmounts on navigation, so the refill runs again each time it is reopened.
+  useEffect(() => {
+    if (restoredKeyRef.current === activeKey || sendableTopics.length === 0) return
+    restoredKeyRef.current = activeKey
+    const restored = loadProducerScope(activeKey)
+    setScope(restored)
+    if (!restored.lastTopic || !sendableTopics.includes(restored.lastTopic)) {
+      // Drop a selection carried over from the previous connection — the select has no
+      // matching option for it, so it would silently send to a topic that is not shown.
+      setTopic((current) => (sendableTopics.includes(current) ? current : ''))
+      return
+    }
+    setTopic(restored.lastTopic)
+    const draft = restored.drafts[restored.lastTopic]
+    if (!draft) return
+    setTag(draft.tag)
+    setKey(draft.key)
+    setDelay(draft.delay)
+    setBody(draft.body)
+  }, [activeKey, sendableTopics])
+
+  const handleTopicChange = (next: string) => {
+    setTopic(next)
+    const draft = next ? scope.drafts[next] : undefined
+    // Leave the form untouched when the topic has nothing saved, so writing the body
+    // first and picking the topic afterwards still works.
+    if (!draft) return
+    setTag(draft.tag)
+    setKey(draft.key)
+    setDelay(draft.delay)
+    setBody(draft.body)
+  }
 
   const handleFormat = () => {
     try {
@@ -100,6 +140,7 @@ export function ProducerPage({ onNavigate }: { onNavigate?: (id: NavId) => void 
         result,
       }
       setHistory((h) => [entry, ...h].slice(0, 50))
+      setScope(saveProducerDraft(activeKey, topic, { tag, key, delay, body }))
       toast.success(t('producer.sendSuccess'), { description: result })
     } catch (e) {
       const msg = formatErrorMessage(e)
@@ -124,6 +165,9 @@ export function ProducerPage({ onNavigate }: { onNavigate?: (id: NavId) => void 
     setKey('')
     setDelay(0)
     setBody('')
+    // Also forget the saved content, otherwise leaving and returning would bring it back
+    // and the reset would look like it never happened.
+    if (topic) setScope(clearProducerDraft(activeKey, topic))
   }
 
   const subtitle = !hasOnline ? t('producer.subtitleNoConn') : t('producer.subtitle')
@@ -157,7 +201,7 @@ export function ProducerPage({ onNavigate }: { onNavigate?: (id: NavId) => void 
                     <Select
                       className="font-mono-design"
                       value={topic}
-                      onChange={(e) => setTopic(e.target.value)}
+                      onChange={(e) => handleTopicChange(e.target.value)}
                     >
                       <option value="">{t('producer.topicPlaceholder')}</option>
                       {sendableTopics.map((tp) => (
@@ -166,6 +210,11 @@ export function ProducerPage({ onNavigate }: { onNavigate?: (id: NavId) => void 
                         </option>
                       ))}
                     </Select>
+                  )}
+                  {topic && scope.drafts[topic] && (
+                    <span className="text-muted-foreground text-fs-105">
+                      {t('producer.draftRestored')}
+                    </span>
                   )}
                 </div>
 
@@ -229,7 +278,13 @@ export function ProducerPage({ onNavigate }: { onNavigate?: (id: NavId) => void 
                 </div>
 
                 <div className="flex items-center gap-2">
-                  <Button variant="ghost" size="sm" onClick={handleReset} disabled={busy}>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={handleReset}
+                    disabled={busy}
+                    title={t('producer.resetTitle')}
+                  >
                     <RotateCcw size={13} />
                     {t('producer.reset')}
                   </Button>

--- a/desktop/tests/e2e/producer-drafts.spec.ts
+++ b/desktop/tests/e2e/producer-drafts.spec.ts
@@ -1,0 +1,309 @@
+import { mkdir, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { resolve } from 'node:path'
+import {
+  test,
+  expect,
+  _electron as electron,
+  type ElectronApplication,
+  type Locator,
+  type Page,
+} from '@playwright/test'
+
+interface Connection {
+  id: number
+  nameServer: string
+  status: 'online' | 'offline'
+}
+
+interface ClusterInfo {
+  clusterName: string
+  brokers: Array<{ brokerName: string; address: string }>
+}
+
+interface TopicItem {
+  topic: string
+}
+
+interface MessageItem {
+  messageId: string
+  topic: string
+  body: string
+}
+
+const desktopRoot = resolve(import.meta.dirname, '../..')
+const testHome = resolve(tmpdir(), `rocket-leaf-producer-drafts-e2e-${process.pid}`)
+const daemonPlatform =
+  process.platform === 'darwin' ? 'mac' : process.platform === 'win32' ? 'win' : 'linux'
+const daemonArch = process.arch === 'x64' ? 'x64' : 'arm64'
+const daemonPath = resolve(
+  desktopRoot,
+  'resources/bin',
+  daemonPlatform,
+  daemonArch,
+  process.platform === 'win32' ? 'rocket-leafd.exe' : 'rocket-leafd',
+)
+
+const stamp = Date.now()
+const topicA = `RocketLeafDraftA_${stamp}`
+const topicB = `RocketLeafDraftB_${stamp}`
+const bodyA = '{"who":"A"}'
+const bodyB = '{"who":"B"}'
+
+// The daemon ships zh as the default language, and a fresh HOME never overrides it.
+const DRAFT_HINT = '已保存该 Topic 上次发送的内容'
+const SEND_OK = '消息已发送'
+const TOPIC_PLACEHOLDER = '选择 Topic'
+const DELAY_NONE = '不延迟'
+const DELAY_1S = '1 秒'
+const STORAGE_KEY = 'rocket-leaf:producer-drafts'
+
+let app: ElectronApplication
+let page: Page
+let clusterName = 'DefaultCluster'
+const electronLogs: string[] = []
+
+async function backend<T>(operation: string, payload?: Record<string, unknown>): Promise<T> {
+  return page.evaluate(
+    ({ operation, payload }) =>
+      window.rocketLeaf.backend.call<T>({
+        operation: operation as Parameters<typeof window.rocketLeaf.backend.call>[0]['operation'],
+        payload,
+      }),
+    { operation, payload },
+  )
+}
+
+async function waitFor<T>(action: () => Promise<T>, predicate: (value: T) => boolean): Promise<T> {
+  let lastValue: T | undefined
+  let lastError: unknown
+  for (let attempt = 0; attempt < 30; attempt += 1) {
+    try {
+      lastValue = await action()
+      if (predicate(lastValue)) return lastValue
+    } catch (error) {
+      lastError = error
+    }
+    await new Promise((resolveDelay) => setTimeout(resolveDelay, 1_000))
+  }
+  throw lastError ?? new Error(`wait condition timed out, last value: ${JSON.stringify(lastValue)}`)
+}
+
+const nav = (label: string) => page.getByRole('button', { name: label, exact: true })
+// `Select` is a Radix Popover combobox, not a native <select>: the trigger carries the
+// current label as text and the options only exist in a portal while it is open.
+const topicSelect = () => page.getByRole('combobox').first()
+const delaySelect = () => page.getByRole('combobox').nth(1)
+const tagInput = () => page.getByPlaceholder('如 order.create')
+const keyInput = () => page.getByPlaceholder('如 ORD-...')
+const bodyArea = () => page.locator('textarea')
+const sendButton = () => page.getByRole('button', { name: '发送', exact: true })
+const resetButton = () => page.getByRole('button', { name: '重置', exact: true })
+
+async function openProducer(): Promise<void> {
+  await expect(nav('发送测试')).toBeEnabled({ timeout: 30_000 })
+  await nav('发送测试').click()
+  await expect(page.getByText('发送测试消息')).toBeVisible()
+  await expect(topicSelect()).toBeVisible({ timeout: 30_000 })
+}
+
+/** Opens a combobox and picks an option, retrying while the topic list is still loading. */
+async function pick(trigger: Locator, optionName: string): Promise<void> {
+  const option = page.getByRole('option', { name: optionName, exact: true })
+  await expect
+    .poll(
+      async () => {
+        await page.keyboard.press('Escape')
+        await trigger.click()
+        return option.count()
+      },
+      { timeout: 30_000 },
+    )
+    .toBe(1)
+  await option.click()
+  await expect(trigger).toHaveText(optionName)
+}
+
+/** Sends and waits for the toast to come and go, so the next send starts from a clean slate. */
+async function send(): Promise<void> {
+  await sendButton().click()
+  await expect(page.getByText(SEND_OK)).toBeVisible({ timeout: 20_000 })
+  await expect(page.getByText(SEND_OK)).toBeHidden({ timeout: 20_000 })
+}
+
+async function expectForm(fields: {
+  topic: string
+  tag: string
+  key: string
+  delay: string
+  body: string
+}): Promise<void> {
+  await expect(topicSelect()).toHaveText(fields.topic)
+  await expect(tagInput()).toHaveValue(fields.tag)
+  await expect(keyInput()).toHaveValue(fields.key)
+  await expect(delaySelect()).toHaveText(fields.delay)
+  await expect(bodyArea()).toHaveValue(fields.body)
+}
+
+test.beforeAll(async () => {
+  await mkdir(testHome, { recursive: true })
+  app = await electron.launch({
+    args: ['.'],
+    cwd: desktopRoot,
+    env: {
+      ...process.env,
+      HOME: testHome,
+      GOCACHE: resolve(tmpdir(), 'rocket-leaf-go-build'),
+      ROCKET_LEAF_DAEMON_PATH: daemonPath,
+    },
+  })
+  app.process().stdout?.on('data', (chunk) => electronLogs.push(chunk.toString()))
+  app.process().stderr?.on('data', (chunk) => electronLogs.push(chunk.toString()))
+  page = await app.firstWindow()
+  await page.waitForLoadState('domcontentloaded')
+  try {
+    await expect
+      .poll(() => page.evaluate(() => window.rocketLeaf.daemon.state()), { timeout: 20_000 })
+      .toBe('ready')
+  } catch (error) {
+    throw new Error(`Electron daemon not ready:\n${electronLogs.join('')}`, { cause: error })
+  }
+
+  const created = await backend<Connection>('connections.add', {
+    name: 'Draft E2E',
+    env: 'test',
+    nameServer: '127.0.0.1:9876',
+    timeoutSec: 10,
+    enableACL: false,
+    accessKey: '',
+    secretKey: '',
+    remark: '',
+  })
+  await backend('connections.connect', { id: created.id })
+
+  const cluster = await waitFor(
+    () => backend<ClusterInfo>('cluster.info'),
+    (value) => value.brokers.some((b) => b.brokerName === 'broker-a'),
+  )
+  clusterName = cluster.clusterName
+  const brokerAddr = cluster.brokers.find((b) => b.brokerName === 'broker-a')!.address
+  for (const topic of [topicA, topicB]) {
+    await backend('topics.create', {
+      topic,
+      brokerAddr,
+      readQueue: 4,
+      writeQueue: 4,
+      perm: 'RW',
+    })
+  }
+  await waitFor(
+    () => backend<TopicItem[]>('topics.list'),
+    (items) => [topicA, topicB].every((t) => items.some((item) => item.topic === t)),
+  )
+
+  // Pick up the now-online connection instead of waiting out the 30s poll.
+  await page.reload()
+  await page.waitForLoadState('domcontentloaded')
+})
+
+test.afterAll(async () => {
+  for (const topic of [topicA, topicB]) {
+    await backend('topics.remove', { topic, clusterName }).catch(() => {})
+  }
+  await app?.close()
+  await rm(testHome, { recursive: true, force: true })
+})
+
+test('remembers the last sent content per topic', async () => {
+  await openProducer()
+
+  // --- send to topic A ------------------------------------------------------
+  await expect(topicSelect()).toHaveText(TOPIC_PLACEHOLDER)
+  await pick(topicSelect(), topicA)
+  await tagInput().fill('tag-a')
+  await keyInput().fill('key-a')
+  await pick(delaySelect(), DELAY_1S)
+  await bodyArea().fill(bodyA)
+  await expect(page.getByText(DRAFT_HINT)).toBeHidden()
+  await send()
+
+  // The UI action really reached RocketMQ, not just localStorage.
+  const delivered = await waitFor(
+    () =>
+      backend<MessageItem[]>('messages.query', {
+        topic: topicA,
+        key: '',
+        tag: '',
+        maxResults: 10,
+        startTime: Date.now() - 120_000,
+        endTime: Date.now() + 120_000,
+      }),
+    (items) => items.some((item) => item.body.includes('"who":"A"')),
+  )
+  expect(delivered.some((item) => item.topic === topicA)).toBe(true)
+
+  // --- leaving and returning restores topic A -------------------------------
+  await nav('概览').click()
+  await openProducer()
+  await expectForm({ topic: topicA, tag: 'tag-a', key: 'key-a', delay: DELAY_1S, body: bodyA })
+  await expect(page.getByText(DRAFT_HINT)).toBeVisible()
+
+  // --- a topic with no saved content leaves the form alone ------------------
+  await pick(topicSelect(), topicB)
+  await expect(page.getByText(DRAFT_HINT)).toBeHidden()
+  await expectForm({ topic: topicB, tag: 'tag-a', key: 'key-a', delay: DELAY_1S, body: bodyA })
+
+  // --- send different content to topic B ------------------------------------
+  await tagInput().fill('tag-b')
+  await keyInput().fill('key-b')
+  await pick(delaySelect(), DELAY_NONE)
+  await bodyArea().fill(bodyB)
+  await send()
+
+  // --- each topic keeps its own content -------------------------------------
+  await pick(topicSelect(), topicA)
+  await expectForm({ topic: topicA, tag: 'tag-a', key: 'key-a', delay: DELAY_1S, body: bodyA })
+  await pick(topicSelect(), topicB)
+  await expectForm({ topic: topicB, tag: 'tag-b', key: 'key-b', delay: DELAY_NONE, body: bodyB })
+
+  // --- content survives a full renderer reload ------------------------------
+  await page.reload()
+  await page.waitForLoadState('domcontentloaded')
+  await openProducer()
+  // topic B was the last one actually sent to, so that is where the page reopens.
+  await expectForm({ topic: topicB, tag: 'tag-b', key: 'key-b', delay: DELAY_NONE, body: bodyB })
+  await pick(topicSelect(), topicA)
+  await expectForm({ topic: topicA, tag: 'tag-a', key: 'key-a', delay: DELAY_1S, body: bodyA })
+
+  // --- reset clears the form and forgets the saved content ------------------
+  await resetButton().click()
+  await expectForm({ topic: topicA, tag: '', key: '', delay: DELAY_NONE, body: '' })
+  await expect(page.getByText(DRAFT_HINT)).toBeHidden()
+
+  await nav('概览').click()
+  await openProducer()
+  // Topic B is still the last topic sent to, and resetting A left its content untouched.
+  await expectForm({ topic: topicB, tag: 'tag-b', key: 'key-b', delay: DELAY_NONE, body: bodyB })
+  // A has nothing saved any more, so switching to it restores nothing and shows no hint —
+  // and, by design, leaves whatever is currently in the form alone.
+  await pick(topicSelect(), topicA)
+  await expect(page.getByText(DRAFT_HINT)).toBeHidden()
+  await expectForm({ topic: topicA, tag: 'tag-b', key: 'key-b', delay: DELAY_NONE, body: bodyB })
+
+  // --- what actually landed in localStorage ---------------------------------
+  const stored = await page.evaluate((k) => localStorage.getItem(k), STORAGE_KEY)
+  expect(stored).toBeTruthy()
+  const scopes = JSON.parse(stored!) as Record<
+    string,
+    { lastTopic: string; drafts: Record<string, { tag: string; body: string; savedAt: number }> }
+  >
+  const scopeKeys = Object.keys(scopes)
+  expect(scopeKeys).toHaveLength(1)
+  // Scoped per connection: `${id}:${nameServer}`.
+  expect(scopeKeys[0]).toContain('127.0.0.1:9876')
+  const scope = scopes[scopeKeys[0]]
+  expect(scope.lastTopic).toBe(topicB)
+  expect(Object.keys(scope.drafts)).toEqual([topicB])
+  expect(scope.drafts[topicB].body).toBe(bodyB)
+  expect(scope.drafts[topicB].savedAt).toBeGreaterThan(0)
+})

--- a/scripts/run-electron.sh
+++ b/scripts/run-electron.sh
@@ -66,13 +66,15 @@ prepare_macos_app() {
   codesign --force --deep --sign - "$destination" >/dev/null
 }
 
+# macOS ties privacy grants to a bundle's path plus its code signature. A fresh mktemp
+# path per run made every launch look like a different app, so the Local Network grant
+# never stuck and connections to a LAN NameServer failed with EHOSTUNREACH ("no route to
+# host"). Keep the bundle at a stable path and leave it in place between runs; the ad-hoc
+# signature over identical content is reproducible, so the grant survives.
 with_macos_app() {
-  temp_root="$(mktemp -d "${TMPDIR:-/tmp}/rocket-leaf-electron.XXXXXX")"
-  app_bundle="$temp_root/Rocket Leaf.app"
-  cleanup() {
-    rm -rf "$temp_root"
-  }
-  trap cleanup EXIT INT TERM
+  app_root="${TMPDIR:-/tmp}/rocket-leaf-electron-dev"
+  app_bundle="$app_root/Rocket Leaf.app"
+  mkdir -p "$app_root"
   prepare_macos_app "$app_bundle"
   export ELECTRON_EXEC_PATH="$app_bundle/Contents/MacOS/Rocket Leaf"
   "$@"


### PR DESCRIPTION
## 改了什么

「发送测试消息」页面现在会记住每个 Topic 上次发送用的 Tag / Key / 延迟级别 / 消息体，重新打开页面或切换 Topic 时自动填回。

分支上还有一个无关的 commit（`fix(dev): use a stable macos app bundle path`），修 macOS 下 dev 模式每次启动都丢失「本地网络」授权的问题，需要的话可以拆出去单独提。

## 为什么

页面每次打开都是空的，反复往同一个 Topic 发相似请求只能每次从别处复制粘贴。

## 怎么做的

新增 `desktop/src/renderer/lib/producerDrafts.ts`，参照 `lib/alertRules.ts` 做的 localStorage 存储层。存档按「连接 + Topic」隔离，连接标识复用 `useConnections` 已有的 `${id}:${nameServer}`，不同集群下的同名 Topic 不会串。

几个行为取舍：

- 只在**发送成功**后保存，对应 issue 里「上一次发送」的语义
- 「重置」连存档一起删，否则切走再回来旧内容又冒出来，看着像没生效
- 切到没有存档的 Topic 时不动当前表单，保住「先写消息体再选 Topic」的用法
- 回填要等 Topic 列表加载完，避免把集群上已不存在的 Topic 塞进下拉框

没有放进 daemon 的 `AppSettings`：它是扁平标量结构体，加字段要动四处契约，而且会被原样打进配置导出，消息体属于用户数据。

容量上限：单条消息体 256 KB（超了整条跳过，不截断）、每连接 30 个 Topic、最多 10 个连接，按最久未用淘汰。

测试：`producerDrafts.test.ts` 覆盖存储层，`tests/e2e/producer-drafts.spec.ts` 驱动真实 UI 打真实 broker 走完整流程。`npm run check` 和两个 e2e spec 都通过。

## 关联

Closes #37
