### PR TITLE
fix(shell): align the title bar to one rhythm

### DIFF
--- a/frontend/src/design/shell/CommandPalette.tsx
+++ b/frontend/src/design/shell/CommandPalette.tsx
@@ -163,8 +163,10 @@ export function CommandPalette({
         if (!next) onClose?.();
       }}
     >
+      {/* Centred both ways, on the dialog's own default: the palette was
+          pinned 96px from the top, which sat high in a window this tall. */}
       <DialogContent
-        className="top-24 translate-y-0 overflow-hidden p-0 sm:max-w-[560px]"
+        className="overflow-hidden p-0 sm:max-w-[560px]"
         showCloseButton={false}
       >
         <DialogHeader className="sr-only">

--- a/frontend/src/design/shell/IconBtn.tsx
+++ b/frontend/src/design/shell/IconBtn.tsx
@@ -5,14 +5,23 @@ import { cn } from "@/lib/utils";
 /*
  * lucide draws on a 24 grid and inks about 20 of it, so 17px puts these within
  * a pixel of the 14px the GitHub mark fills solid, and a stroked set beside a
- * filled brand mark reads as one row. Expressed in rem (17/13) so the cluster
- * follows the font-size setting, and carrying `size-` so the Button's own
+ * filled brand mark reads as one row. It carries `size-` so the Button's own
  * icon sizing rule leaves it alone.
+ *
+ * In px, not rem. This was `1.3rem`, written as 17/13 against BASE_FONT_SIZE --
+ * but the scale ladder zooms the document rather than setting a root font size
+ * (see useUIScale), so the root stays at the browser's 16 and that rem rendered
+ * as 20.8px. `zoom` already scales everything, so px is both accurate and the
+ * only thing rem was there to buy.
  */
-export const ICON_CLASS = "size-[1.3rem]";
+export const ICON_CLASS = "size-[17px]";
 
 /**
- * A 26px ghost icon button in the title bar cluster.
+ * A 28px ghost icon button in the title bar cluster.
+ *
+ * 28 rather than shadcn's `icon-sm`, which is 32: the bar is 40px tall around
+ * 30px tabs, and a 32px box stands taller than the tabs beside it, which is
+ * what made the cluster read as the heaviest thing in the row.
  *
  * Lives here rather than in TitleBar because the bell is its own popover
  * trigger: the notification centre has to render this button itself, and
@@ -29,7 +38,8 @@ export function IconBtn({
       size="icon-sm"
       aria-pressed={active}
       className={cn(
-        "flex-none text-foreground/80",
+        // Overrides icon-sm's size-8; tailwind-merge keeps the later class.
+        "size-7 flex-none text-foreground/80",
         active && "bg-accent text-accent-foreground",
         className,
       )}

--- a/frontend/src/design/shell/IconBtn.tsx
+++ b/frontend/src/design/shell/IconBtn.tsx
@@ -11,8 +11,8 @@ import { cn } from "@/lib/utils";
  * In px, not rem. This was `1.3rem`, written as 17/13 against BASE_FONT_SIZE --
  * but the scale ladder zooms the document rather than setting a root font size
  * (see useUIScale), so the root stays at the browser's 16 and that rem rendered
- * as 20.8px. `zoom` already scales everything, so px is both accurate and the
- * only thing rem was there to buy.
+ * as 20.8px. Scaling with the setting is the one thing the rem was there to
+ * buy, and `zoom` already provides it.
  */
 export const ICON_CLASS = "size-[17px]";
 

--- a/frontend/src/design/shell/TitleBar.tsx
+++ b/frontend/src/design/shell/TitleBar.tsx
@@ -138,7 +138,7 @@ export function TitleBar({
         {updateAvailable != null && <Badge tone="var(--c-ok)" />}
       </IconBtn>
       <IconBtn onClick={onGithub} title={t("shell.titleBar.github")}>
-        <SiGithub className="size-[1.08rem]" color="var(--c-github-mark)" aria-hidden />
+        <SiGithub className="size-[14px]" color="var(--c-github-mark)" aria-hidden />
       </IconBtn>
       {/* Owns its own open state and unread count -- both come from the
           alert centre, which no longer has anything to tell the title bar. */}

--- a/frontend/src/design/shell/TitleBar.tsx
+++ b/frontend/src/design/shell/TitleBar.tsx
@@ -101,11 +101,19 @@ export function TitleBar({
         {tabs ?? <span style={{ flex: 1 }} />}
       </div>
 
+      {/*
+       * 28px and 12.5px rather than shadcn's `sm`, which is 32px and 14px:
+       * those are page defaults and this is a 40px bar. At 32 it stood taller
+       * than everything beside it, and its label ran a size larger than the
+       * tabs' own. Level with the icon cluster, the right of the bar reads as
+       * one group -- and the border still gives it the weight a ghost icon
+       * has not.
+       */}
       <Button
         variant="outline"
         size="sm"
         className={cn(
-          "flex-none bg-background font-normal text-muted-foreground",
+          "h-7 flex-none bg-background px-2.5 text-[12.5px] font-normal text-muted-foreground",
           dimmed && "text-(--c-disabled)",
         )}
         onClick={onSearch}

--- a/frontend/src/design/tokens.css
+++ b/frontend/src/design/tokens.css
@@ -231,11 +231,6 @@
   --wails-draggable: no-drag;
 }
 /*
- * The canvas drew 26px boxes, which left the cluster the shortest thing in a
- * bar of 30px tabs; 28px lines it up with those and gives the icons room. The
- * font-size is the canvas's and now carries nothing -- every child is an SVG.
- */
-/*
  * 检查更新 turns its icon for as long as the check is in flight. TitleBar drops
  * the class on an iteration boundary rather than the moment the answer lands,
  * so the icon always comes to rest upright and a check answered in 50ms still


### PR DESCRIPTION
## What

Brings the title bar onto one rhythm, and centres the command palette.

- **Icons render at the size they were specified.** `ICON_CLASS` was
  `size-[1.3rem]`, written as 17/13 against `BASE_FONT_SIZE` — but the scale
  ladder zooms the document rather than setting a root font size, so the root
  stays at the browser's 16 and that rem came out at 20.8px. The GitHub mark
  had the same fault (14px asked, 17.3px rendered). Both are px now.
- **The icon buttons are 28px**, not shadcn's `icon-sm` 32, so the cluster no
  longer stands taller than the 30px tabs beside it.
- **The search button matches them** at 28px with a 12.5px label, down from
  `sm`'s 32px and 14px — page defaults that were never sized for a 40px bar.
- **The command palette centres both ways**, instead of hanging 96px from the
  top of a window that is at least 750px tall.

## Why

Closes #49, which measured the first two: the cluster rendered 22% larger than
its own comment asked for, and its box was 2px taller than the tabs. Both
predate the update work in #50 — swapping the check-update glyph for a nearly
full-bore circle only made an existing mismatch visible.

The other two came out of looking at the bar afterwards. The search button was
the last thing still sized by a page default, and the palette's fixed offset
read as high once the rest of the bar settled.

`tokens.css` still carried the note that settled the box at 28px, written
against an implementation the shadcn migration had already replaced. The note
described nothing that existed, so it is gone and the value is back.

## How

px rather than rem throughout. Scaling with the font-size setting is the one
thing the rem was there to buy, and `zoom` already provides it — so px is not
a regression in behaviour, it is the accurate spelling of the same intent.

One trade is taken back deliberately: centring the palette means its input
moves as results are filtered, because the panel's height changes and its
centre does not. The fixed offset is what kept the input still. Centring was
the ask, and the commit says so, so nobody restores the offset as a bugfix.

## Testing

`npm run check` passes: version check, frontend build, gofmt, vet, all Go
tests, 59 frontend test files (601 tests), bindings in sync.

Every value was measured in the running app rather than read off the classes —
icon boxes, glyph sizes, the search button's height and font size, and the
palette's centring were each confirmed in the browser, in light and dark, with
the update badge in place.

## Related

Closes #49
