### PR TITLE
fix(shell): clip the update dialog to its radius

### DIFF
--- a/frontend/src/design/shell/UpdateDialog.tsx
+++ b/frontend/src/design/shell/UpdateDialog.tsx
@@ -43,7 +43,13 @@ export function UpdateDialog() {
   const { dialogOpen, closeDialog } = useUpdater();
   return (
     <Dialog open={dialogOpen} onOpenChange={(next) => !next && closeDialog()}>
-      <DialogContent className="gap-0 p-0 sm:max-w-[560px]" showCloseButton={false}>
+      {/* Clipped to the dialog's own radius: the header and footer bars run
+          edge to edge, and their square corners would otherwise paint over
+          the rounded ones. */}
+      <DialogContent
+        className="gap-0 overflow-hidden p-0 sm:max-w-[560px]"
+        showCloseButton={false}
+      >
         <UpdatePanel />
       </DialogContent>
     </Dialog>


### PR DESCRIPTION
## What

Add `overflow-hidden` to the update dialog's `DialogContent`, so the panel is clipped to its own `rounded-lg` radius.

## Why

The dialog is the one `p-0` layout in the app whose header and footer bars run edge to edge. Nothing clipped them, so the footer's opaque `bg-(--c-bar)` painted square corners over the rounded bottom of the panel — the top two corners looked right, the bottom two did not.

The command palette has the same edge-to-edge layout and already carries `overflow-hidden p-0`; this brings the update dialog in line with it.

## Testing

- `npm --prefix frontend run type-check` — clean.
- `npm --prefix frontend test` — 601 tests, 59 files, all pass.
- Rendered the real `DialogContent` against the real stylesheet on a throwaway page, in both themes. With the radius temporarily exaggerated to 36px, the bottom corners are square before the change (`overflow: visible`) and rounded after (`overflow: hidden`); at the shipped 10px radius all four corners match.

No test asserts the class: the dialog's suite renders `UpdatePanel` through `renderToStaticMarkup` because `DialogContent` portals, and its stated convention is that the phase-to-buttons mapping is what matters, not the markup.

## Related

Closes #53