### PR TITLE
ci: split the check job and shard the live suites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,13 @@
-# Runs the same gate as `npm run check` locally: version consistency, gofmt,
-# go vet, frontend type checks, unit tests, and generated-binding drift.
+# The same gate as `npm run check` locally - version consistency, gofmt, go
+# vet, frontend type checks, unit tests, generated-binding drift and the live
+# suites - but split across jobs that run at the same time.
+#
+# The split is not free: sharding the live suites by broker family means a test
+# can go unrun without anything turning red, because every shard that does not
+# claim it skips it. That is the shape of issue #48. The `coverage` job at the
+# bottom is what makes the split safe - it asserts over the shards' combined
+# output that every test passed somewhere. Nothing here is allowed to assert
+# less than the single serial job it replaced.
 name: CI
 
 on:
@@ -14,8 +22,8 @@ on:
   # the two lists have to be kept in step by hand.
   #
   # website/** is excluded because none of this job applies to it and all of it
-  # is expensive: the GTK headers and the four broker clusters below cost about
-  # twenty minutes, which a copy edit should not spend. website.yml gates that
+  # is expensive: the GTK headers and the broker clusters below cost real
+  # minutes, which a copy edit should not spend. website.yml gates that
   # directory instead.
   pull_request:
     paths-ignore:
@@ -32,17 +40,18 @@ permissions:
   contents: read
 
 jobs:
-  check:
-    name: Check
+  # Names the CI artifacts <version>+<short sha> so a downloaded build can be
+  # traced back to its commit without opening the run. Its own job because
+  # `package` needs the value and should not wait on a heavy job to learn it.
+  meta:
+    name: Meta
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 5
     outputs:
       version: ${{ steps.meta.outputs.version }}
     steps:
       - uses: actions/checkout@v7
 
-      # Names the CI artifacts <version>+<short sha> so a downloaded build can
-      # be traced back to its commit without opening the run.
       - name: Resolve the build version
         id: meta
         shell: bash
@@ -50,6 +59,50 @@ jobs:
           set -eu
           version="$(node -p "require('./package.json').version")"
           echo "version=${version}+${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+
+      - name: Check the version is consistent across the tree
+        run: npm run check:version
+
+  # Node only. None of this needs Go, Docker or the GTK headers, and it used to
+  # wait behind all three.
+  frontend:
+    name: Frontend
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install frontend dependencies
+        run: npm ci --prefix frontend
+
+      # type-check and vite build, which is what `npm run build:frontend` is.
+      - name: Type-check and build the frontend
+        run: npm run build:frontend
+
+      - name: Run the frontend tests
+        run: npm run test:frontend
+
+  # Everything that needs the whole tree to compile: vet, the generated-binding
+  # drift check, and the tests that need no broker.
+  #
+  # The unit tests live here rather than in a job of their own because this job
+  # already compiles the tree for vet, and because `./...` reaches
+  # internal/bridge and internal/tray - the only packages that import wails, and
+  # so the only reason the GTK headers are installed anywhere in this file. Its
+  # results are also the test inventory the coverage job checks the shards
+  # against, which has to be a run that names every test in the repository.
+  static:
+    name: Static checks and unit tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
 
       - uses: actions/setup-go@v6
         with:
@@ -76,116 +129,220 @@ jobs:
             libwebkitgtk-6.0-dev
 
       # The binding drift check regenerates them, so the CLI has to match the
-      # version the module pins.
-      - name: Install the Wails CLI
+      # version the module pins - which is also why the cache key can only go
+      # stale by changing go.mod, at which point the key changes with it.
+      - name: Resolve the Wails CLI version
+        id: wails
         run: |
           set -eu
-          wails_version="$(awk '/github.com\/wailsapp\/wails\/v3/ { print $2; exit }' go.mod)"
-          go install "github.com/wailsapp/wails/v3/cmd/wails3@${wails_version}"
-          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+          echo "version=$(awk '/github.com\/wailsapp\/wails\/v3/ { print $2; exit }' go.mod)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache the Wails CLI
+        id: wails-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/go/bin/wails3
+          key: wails3-${{ runner.os }}-${{ steps.wails.outputs.version }}
+
+      - name: Install the Wails CLI
+        if: steps.wails-cache.outputs.cache-hit != 'true'
+        run: go install "github.com/wailsapp/wails/v3/cmd/wails3@${{ steps.wails.outputs.version }}"
+
+      - name: Put the Wails CLI on PATH
+        run: echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
       - name: Install frontend dependencies
         run: npm ci --prefix frontend
 
-      # Every live suite gates through internal/e2e: it skips when the
-      # environment it needs is absent, so a checkout without docker still has
-      # a green suite, and fails outright when CI is set, because a contract
-      # test that can silently not run asserts nothing. Each environment below
-      # therefore has to be up before the checks or the run is red - which is
-      # the point, and is what these tests could not do while an unset variable
-      # was allowed to skip them (#48).
-      #
+      # main.go embeds frontend/dist, which is gitignored, so the tree does not
+      # compile without it. A placeholder would satisfy the embed and stop it
+      # being checked, so this is the real build - minus the type check, which
+      # is the frontend job's to run and not worth paying for twice.
+      - name: Build the frontend for the embed
+        working-directory: frontend
+        run: npx vite build --mode production
+
+      - name: Check gofmt
+        run: npm run go:fmt:check
+
+      - name: Vet
+        run: npm run go:vet
+
+      # No broker is running here, so this claims no families and every live
+      # test skips. The e2e shards below are where they run, and the coverage
+      # job is what proves it.
+      - name: Run the tests that need no broker
+        env:
+          MQ_STUDIO_E2E_FAMILIES: none
+        run: |
+          set -euo pipefail
+          go test -json -count=1 ./... | tee results-unit.json | jq -j 'select(.Action == "output") | .Output'
+
+      - name: Upload the unit results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: results-unit
+          path: results-unit.json
+          retention-days: 7
+
+      - name: Check for generated-binding drift
+        run: npm run check:bindings
+
+  # One job per broker family. Each starts only its own compose stacks and
+  # claims only its own family, so the families run at the same time instead of
+  # queueing behind each other in a single `go test ./...`.
+  #
+  # None of these install the GTK headers, the Wails CLI or the frontend
+  # dependencies: no package under internal/app or internal/driver reaches
+  # wails, and the e2e:* scripts are shells around docker compose that the
+  # runner's own node can run without an install.
+  #
+  # Adding a family here is not optional - internal/e2e.AllFamilies is pinned
+  # against this matrix by TestEveryFamilyHasACIShard, and a family with no
+  # shard would skip in every job of the run.
+  e2e:
+    name: E2E (${{ matrix.family }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      # A red family should not cancel the others: which families still pass
+      # is most of what says whether a failure is the change or the cluster.
+      fail-fast: false
+      matrix:
+        include:
+          - family: rocketmq
+            packages: ./internal/app/... ./internal/driver/rocketmq/...
+            # The consumer group the live tests read. mq-studio cannot create
+            # one - see TestLiveConsumerGroupDelete for why - so it is seeded.
+            # The second broker has authentication on, and is separate because
+            # a broker with ACL enabled refuses every unauthenticated call the
+            # other tests make.
+            up: |
+              npm run e2e:up
+              npm run e2e:seed
+              npm run e2e:acl:up
+          - family: rabbitmq
+            packages: ./internal/app/... ./internal/driver/rabbitmq/...
+            # The second broker has none of the optional plugins. What a
+            # missing plugin degrades to cannot be asserted against the first
+            # one, which turns them on so their pages have something to read.
+            up: |
+              npm run e2e:rabbitmq:up
+              npm run e2e:rabbitmq:plain:up
+          - family: kafka
+            packages: ./internal/app/... ./internal/driver/kafka/...
+            # Three brokers, which the app-layer cross-checks also drive
+            # through Kafka's own CLI inside the first container. The second
+            # cluster has SASL and an authorizer: what a rejected credential
+            # looks like and what an ACL round trip does cannot be asserted
+            # against the first one, which runs without either.
+            up: |
+              npm run e2e:kafka:up
+              npm run e2e:kafka:secure:up
+          - family: pulsar
+            packages: ./internal/app/... ./internal/driver/pulsar/...
+            # The seed is required, unlike the others. The cross-check compares
+            # figures the app computes against the same figures from
+            # pulsar-admin, and comparing zero against zero would pass whatever
+            # the driver did.
+            up: |
+              npm run e2e:pulsar:up
+              npm run e2e:pulsar:seed
+          - family: redis
+            packages: ./internal/app/... ./internal/driver/redisstream/...
+            # ACL on rather than a bare password: the driver has a page for it.
+            # The cluster is six nodes, because a single server cannot produce a
+            # CLUSTER NODES with more than one row, a slot that belongs to a
+            # node you did not ask, or a refused cross-slot command.
+            up: |
+              npm run e2e:redis:up
+              npm run e2e:redis:cluster:up
+          - family: mqtt
+            packages: ./internal/app/... ./internal/driver/mqtt/...
+            # Mosquitto has no management API and publishes a full $SYS tree;
+            # EMQX refuses a remote client's $SYS subscription and answers over
+            # REST instead. Neither broker alone covers both tiers.
+            up: |
+              npm run e2e:mqtt:up
+              npm run e2e:mqtt:emqx:up
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache-dependency-path: go.sum
+
       # Same compose files a developer runs, so the images, the credentials and
       # the plugins match.
-      - name: Start RocketMQ
-        run: npm run e2e:up
+      - name: Start ${{ matrix.family }}
+        run: ${{ matrix.up }}
 
-      # The consumer group the live tests read. mq-studio cannot create one -
-      # see TestLiveConsumerGroupDelete for why - so the broker is seeded.
-      - name: Seed RocketMQ
-        run: npm run e2e:seed
-
-      # A third broker, with authentication on. Separate because a broker with
-      # ACL enabled refuses every unauthenticated call the other tests make.
-      - name: Start the ACL-enabled RocketMQ
-        run: npm run e2e:acl:up
-
-      - name: Start RabbitMQ
-        run: npm run e2e:rabbitmq:up
-
-      # A second broker with none of the optional plugins. What a missing
-      # plugin degrades to cannot be asserted against the first one, which
-      # turns them on so their pages have something to read.
-      - name: Start the plugin-free RabbitMQ
-        run: npm run e2e:rabbitmq:plain:up
-
-      # Three Kafka brokers, which the app-layer cross-checks also drive
-      # through Kafka's own CLI inside the first container.
-      - name: Start Kafka
-        run: npm run e2e:kafka:up
-
-      # A second cluster with SASL and an authorizer. What a rejected
-      # credential looks like and what an ACL round trip does cannot be
-      # asserted against the first one, which runs without either.
-      - name: Start the secure Kafka
-        run: npm run e2e:kafka:secure:up
-
-      # Standalone boots BookKeeper and the metadata store before the broker
-      # answers, so this is the slowest of the six to come up. Its compose
-      # healthcheck waits; --wait is what makes this step do the same.
-      - name: Start Pulsar
-        run: npm run e2e:pulsar:up
-
-      # Required, unlike the other seeds. The cross-check compares figures the
-      # app computes against the same figures from pulsar-admin, and comparing
-      # zero against zero would pass whatever the driver did.
-      - name: Seed Pulsar
-        run: npm run e2e:pulsar:seed
-      # ACL on rather than a bare password: the driver has a page for it, and
-      # a broker with no users to read would leave both the ACL board and the
-      # rejected-credentials path untested.
-      - name: Start Redis
-        run: npm run e2e:redis:up
-
-      # Six nodes. A single server cannot produce a CLUSTER NODES with more
-      # than one row, a slot that belongs to a node you did not ask, or a
-      # refused cross-slot command, and those are what the cluster board and
-      # the driver's per-key call shape exist for.
-      - name: Start the Redis cluster
-        run: npm run e2e:redis:cluster:up
-      # Mosquitto has no management API at all and publishes a full $SYS tree.
-      # It is the broker the degraded management path is asserted against, and
-      # the only one either half of the $SYS reader can be checked on.
-      - name: Start Mosquitto
-        run: npm run e2e:mqtt:up
-
-      # EMQX is the other half: its default authorisation refuses a remote
-      # client's $SYS subscription and its REST API answers everything the
-      # protocol cannot. Neither broker alone covers both tiers.
-      - name: Start EMQX
-        run: npm run e2e:mqtt:emqx:up
-
-      - name: Run checks
-        # The opt-in a developer sets locally. CI does not need it - internal/e2e
-        # does not consult it when CI is set, so that no unset variable can be
-        # the reason a suite did not run - but setting it here keeps the local
-        # repro of a CI failure the same command.
+      # MQ_STUDIO_E2E is the opt-in a developer sets locally. CI does not need
+      # it - internal/e2e does not consult it when CI is set, so that no unset
+      # variable can be the reason a suite did not run - but setting it here
+      # keeps the local repro of a CI failure the same command.
+      #
+      # MQ_STUDIO_E2E_FAMILIES is what makes the shard a shard: the families it
+      # does not name skip, and the ones it does still fail rather than skip
+      # when their environment is absent.
+      - name: Run the ${{ matrix.family }} suite
         env:
           MQ_STUDIO_E2E: '1'
-        run: npm run check
+          MQ_STUDIO_E2E_FAMILIES: ${{ matrix.family }}
+        run: |
+          set -euo pipefail
+          go test -json -count=1 ${{ matrix.packages }} \
+            | tee "results-${{ matrix.family }}.json" \
+            | jq -j 'select(.Action == "output") | .Output'
 
-  # Exercises the real packaging path for all six targets. It is skipped on pull
-  # requests to keep review feedback fast, but running it on every push to main
-  # means a packaging break surfaces then rather than on release day, which is
-  # when it used to.
+      - name: Upload the ${{ matrix.family }} results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: results-${{ matrix.family }}
+          path: results-${{ matrix.family }}.json
+          retention-days: 7
+
+  # The reason the split above is allowed to exist. Sharding lets a test go
+  # unrun without anything turning red; this asserts over every shard's output
+  # that each test passed somewhere, and fails when the only thing that
+  # happened to it was the gate skipping it.
+  coverage:
+    name: Live coverage
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: [static, e2e]
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Download every shard's results
+        uses: actions/download-artifact@v4
+        with:
+          pattern: results-*
+          path: results
+          merge-multiple: true
+
+      - name: Check that every test ran somewhere
+        run: node scripts/ci-coverage.mjs results
+
+  # Exercises the real packaging path for all six targets. It is skipped on
+  # pull requests to keep review feedback fast, but running it on every push to
+  # main means a packaging break surfaces then rather than on release day,
+  # which is when it used to.
+  #
+  # It waits on the live coverage rather than only on the shards, so an
+  # artifact is never produced from a run that quietly tested less than it
+  # should have.
   package:
     name: Package
     if: github.event_name != 'pull_request'
-    needs: check
+    needs: [meta, frontend, static, e2e, coverage]
     uses: ./.github/workflows/package.yml
     with:
       ref: ${{ github.sha }}
-      package-version: ${{ needs.check.outputs.version }}
+      package-version: ${{ needs.meta.outputs.version }}
       sign: false
       retention-days: 7
     # No secrets passed: an unsigned build has no use for the signing material,

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -103,10 +103,16 @@ jobs:
           ref: ${{ inputs.ref }}
           fetch-depth: 0
 
+      # No Go cache here on purpose. Each target builds once on a runner of its
+      # own and reuses nothing, so the cache buys these jobs almost nothing -
+      # but six of them saving ~1 GB each was pushing the repository past the
+      # 10 GB Actions cache limit on every push to main, which evicted the one
+      # cache that does pay off: ci.yml's, whose absence made every CI run
+      # recompile the cgo tree from cold.
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-          cache-dependency-path: go.sum
+          cache: false
 
       - uses: actions/setup-node@v7
         with:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -128,7 +128,23 @@ and MQ Studio starts empty. Copying those files over by hand does not help
 either, because `crypto.hkdfInfoPrefix` feeds key derivation and was renamed
 too, so the stored `ENC:` values no longer decrypt.
 
-`.github/workflows/ci.yml` runs the same gate on pushes and pull requests.
+`.github/workflows/ci.yml` runs the same gate on pushes and pull requests, but
+splits it across jobs that run at the same time: the frontend build and tests
+need neither Go nor Docker, the static checks are the only thing that needs the
+GTK headers, and the live suites are sharded one job per broker family, each
+starting only its own compose stacks.
+
+That last split is not free. `MQ_STUDIO_E2E_FAMILIES` tells `internal/e2e`
+which families a shard is responsible for, and the ones it does not name skip -
+so a test can now go unrun without anything turning red, which is how issue #48
+went unnoticed. Two things stop that. `TestEveryFamilyHasACIShard` pins
+`e2e.AllFamilies` against the workflow's shard matrix, and the `coverage` job
+runs `scripts/ci-coverage.mjs` over every shard's `go test -json` output to
+assert that each test passed in at least one of them. A skip only counts as
+deliberate if it did not come from the gate, which is what `e2e.SkipMarker`
+distinguishes. `package` waits on that job, so an artifact is never produced
+from a run that tested less than it should have.
+
 `release.yml` packages a tag. Its runner matrix follows what each platform needs
 to compile: macOS builds both slices from one SDK and joins them with `lipo`,
 Windows cross-compiles both architectures from one runner because it does not

--- a/internal/app/kafka_crosscheck_test.go
+++ b/internal/app/kafka_crosscheck_test.go
@@ -105,8 +105,9 @@ func newKafkaStack(t *testing.T) *kafkaStack {
 func requireKafkaCLI(t *testing.T) {
 	t.Helper()
 	e2e.Require(t, e2e.Env{
-		Name:  "the kafka e2e cluster",
-		Start: "npm run e2e:kafka:up",
+		Name:   "the kafka e2e cluster",
+		Family: e2e.Kafka,
+		Start:  "npm run e2e:kafka:up",
 		// The cross-checks run Kafka's own tools inside the container, so a
 		// reachable port is not enough to say the environment is there.
 		Probe: e2e.DockerContainer(kafkaContainer),

--- a/internal/app/live_test.go
+++ b/internal/app/live_test.go
@@ -56,18 +56,20 @@ const (
 func requireLiveBroker(t *testing.T) {
 	t.Helper()
 	e2e.Require(t, e2e.Env{
-		Name:  "the rocketmq broker",
-		Start: "npm run e2e:up",
-		Probe: e2e.DialTCP(liveNameServer),
+		Name:   "the rocketmq broker",
+		Family: e2e.RocketMQ,
+		Start:  "npm run e2e:up",
+		Probe:  e2e.DialTCP(liveNameServer),
 	})
 }
 
 func requireACLBroker(t *testing.T) {
 	t.Helper()
 	e2e.Require(t, e2e.Env{
-		Name:  "the ACL-enabled rocketmq broker",
-		Start: "npm run e2e:acl:up",
-		Probe: e2e.DialTCP(aclNameServer),
+		Name:   "the ACL-enabled rocketmq broker",
+		Family: e2e.RocketMQ,
+		Start:  "npm run e2e:acl:up",
+		Probe:  e2e.DialTCP(aclNameServer),
 	})
 }
 

--- a/internal/app/mqtt_live_test.go
+++ b/internal/app/mqtt_live_test.go
@@ -40,18 +40,20 @@ const (
 func requireLiveMosquitto(t *testing.T) {
 	t.Helper()
 	e2e.Require(t, e2e.Env{
-		Name:  "mosquitto",
-		Start: "npm run e2e:mqtt:up",
-		Probe: e2e.DialTCP(liveMosquitto),
+		Name:   "mosquitto",
+		Family: e2e.MQTT,
+		Start:  "npm run e2e:mqtt:up",
+		Probe:  e2e.DialTCP(liveMosquitto),
 	})
 }
 
 func requireLiveEMQX(t *testing.T) {
 	t.Helper()
 	e2e.Require(t, e2e.Env{
-		Name:  "emqx",
-		Start: "npm run e2e:mqtt:emqx:up",
-		Probe: e2e.HTTPGet(liveEMQXAPI + "/api/v5/status"),
+		Name:   "emqx",
+		Family: e2e.MQTT,
+		Start:  "npm run e2e:mqtt:emqx:up",
+		Probe:  e2e.HTTPGet(liveEMQXAPI + "/api/v5/status"),
 	})
 }
 

--- a/internal/app/pulsar_crosscheck_test.go
+++ b/internal/app/pulsar_crosscheck_test.go
@@ -51,8 +51,9 @@ const (
 func requirePulsarCLI(t *testing.T) {
 	t.Helper()
 	e2e.Require(t, e2e.Env{
-		Name:  "the pulsar e2e cluster",
-		Start: "npm run e2e:pulsar:up",
+		Name:   "the pulsar e2e cluster",
+		Family: e2e.Pulsar,
+		Start:  "npm run e2e:pulsar:up",
 		// The cross-check runs Pulsar's own tools inside the container, so a
 		// reachable port is not enough to say the environment is there.
 		Probe: e2e.DockerContainer(pulsarContainer),

--- a/internal/app/pulsar_live_test.go
+++ b/internal/app/pulsar_live_test.go
@@ -21,9 +21,10 @@ const (
 func requireLivePulsar(t *testing.T) {
 	t.Helper()
 	e2e.Require(t, e2e.Env{
-		Name:  "pulsar",
-		Start: "npm run e2e:pulsar:up",
-		Probe: e2e.HTTPGet(livePulsarAdmin + "/admin/v2/brokers/health"),
+		Name:   "pulsar",
+		Family: e2e.Pulsar,
+		Start:  "npm run e2e:pulsar:up",
+		Probe:  e2e.HTTPGet(livePulsarAdmin + "/admin/v2/brokers/health"),
 	})
 }
 

--- a/internal/app/redis_crosscheck_test.go
+++ b/internal/app/redis_crosscheck_test.go
@@ -112,8 +112,9 @@ func newRedisStack(t *testing.T) *redisStack {
 func requireRedisCLI(t *testing.T) {
 	t.Helper()
 	e2e.Require(t, e2e.Env{
-		Name:  "the redis e2e server",
-		Start: "npm run e2e:redis:up",
+		Name:   "the redis e2e server",
+		Family: e2e.Redis,
+		Start:  "npm run e2e:redis:up",
 		// The cross-checks run redis-cli inside the container, so a reachable
 		// port is not enough: the container itself has to be there.
 		Probe: e2e.DockerContainer(redisContainer),

--- a/internal/driver/kafka/live_test.go
+++ b/internal/driver/kafka/live_test.go
@@ -33,9 +33,10 @@ const (
 func requireLiveCluster(t *testing.T) {
 	t.Helper()
 	e2e.Require(t, e2e.Env{
-		Name:  "kafka",
-		Start: "npm run e2e:kafka:up",
-		Probe: e2e.DialTCP(strings.Split(liveSeeds, ",")[0]),
+		Name:   "kafka",
+		Family: e2e.Kafka,
+		Start:  "npm run e2e:kafka:up",
+		Probe:  e2e.DialTCP(strings.Split(liveSeeds, ",")[0]),
 	})
 }
 

--- a/internal/driver/kafka/secure_test.go
+++ b/internal/driver/kafka/secure_test.go
@@ -28,9 +28,10 @@ const (
 func requireSecureCluster(t *testing.T) {
 	t.Helper()
 	e2e.Require(t, e2e.Env{
-		Name:  "the secure kafka cluster",
-		Start: "npm run e2e:kafka:secure:up",
-		Probe: e2e.DialTCP(secureSeeds),
+		Name:   "the secure kafka cluster",
+		Family: e2e.Kafka,
+		Start:  "npm run e2e:kafka:secure:up",
+		Probe:  e2e.DialTCP(secureSeeds),
 	})
 }
 

--- a/internal/driver/mqtt/live_test.go
+++ b/internal/driver/mqtt/live_test.go
@@ -42,18 +42,20 @@ const (
 func requireMosquitto(t *testing.T) {
 	t.Helper()
 	e2e.Require(t, e2e.Env{
-		Name:  "mosquitto",
-		Start: "npm run e2e:mqtt:up",
-		Probe: e2e.DialTCP(liveMosquitto),
+		Name:   "mosquitto",
+		Family: e2e.MQTT,
+		Start:  "npm run e2e:mqtt:up",
+		Probe:  e2e.DialTCP(liveMosquitto),
 	})
 }
 
 func requireEMQX(t *testing.T) {
 	t.Helper()
 	e2e.Require(t, e2e.Env{
-		Name:  "emqx",
-		Start: "npm run e2e:mqtt:emqx:up",
-		Probe: e2e.HTTPGet(liveEMQXAPI + "/api/v5/status"),
+		Name:   "emqx",
+		Family: e2e.MQTT,
+		Start:  "npm run e2e:mqtt:emqx:up",
+		Probe:  e2e.HTTPGet(liveEMQXAPI + "/api/v5/status"),
 	})
 }
 
@@ -175,9 +177,10 @@ func TestLivePublishReachesASubscription(t *testing.T) {
  */
 func TestLiveWebSocketTransportConnects(t *testing.T) {
 	e2e.Require(t, e2e.Env{
-		Name:  "mosquitto over websocket",
-		Start: "npm run e2e:mqtt:up",
-		Probe: e2e.DialTCP(liveMosquittoWS),
+		Name:   "mosquitto over websocket",
+		Family: e2e.MQTT,
+		Start:  "npm run e2e:mqtt:up",
+		Probe:  e2e.DialTCP(liveMosquittoWS),
 	})
 
 	for _, version := range []string{protocol5, protocol311} {

--- a/internal/driver/pulsar/live_test.go
+++ b/internal/driver/pulsar/live_test.go
@@ -21,8 +21,9 @@ const (
 func requireLiveCluster(t *testing.T) {
 	t.Helper()
 	e2e.Require(t, e2e.Env{
-		Name:  "pulsar",
-		Start: "npm run e2e:pulsar:up",
+		Name:   "pulsar",
+		Family: e2e.Pulsar,
+		Start:  "npm run e2e:pulsar:up",
 		// The admin plane, not the broker port: standalone binds 6650 before
 		// the broker has registered, so a dial would pass against a cluster
 		// that cannot answer anything yet.

--- a/internal/driver/rabbitmq/conformance_test.go
+++ b/internal/driver/rabbitmq/conformance_test.go
@@ -27,9 +27,10 @@ const liveEndpoint = "http://127.0.0.1:15672"
 func requireLiveBroker(t *testing.T) {
 	t.Helper()
 	e2e.Require(t, e2e.Env{
-		Name:  "rabbitmq",
-		Start: "npm run e2e:rabbitmq:up",
-		Probe: e2e.HTTPGet(liveEndpoint + "/api/overview"),
+		Name:   "rabbitmq",
+		Family: e2e.RabbitMQ,
+		Start:  "npm run e2e:rabbitmq:up",
+		Probe:  e2e.HTTPGet(liveEndpoint + "/api/overview"),
 	})
 }
 

--- a/internal/driver/rabbitmq/degraded_test.go
+++ b/internal/driver/rabbitmq/degraded_test.go
@@ -27,9 +27,10 @@ const plainEndpoint = "http://127.0.0.1:15682"
 func requirePlainBroker(t *testing.T) {
 	t.Helper()
 	e2e.Require(t, e2e.Env{
-		Name:  "the plugin-free rabbitmq",
-		Start: "npm run e2e:rabbitmq:plain:up",
-		Probe: e2e.HTTPGet(plainEndpoint + "/api/overview"),
+		Name:   "the plugin-free rabbitmq",
+		Family: e2e.RabbitMQ,
+		Start:  "npm run e2e:rabbitmq:plain:up",
+		Probe:  e2e.HTTPGet(plainEndpoint + "/api/overview"),
 	})
 }
 

--- a/internal/driver/redisstream/live_test.go
+++ b/internal/driver/redisstream/live_test.go
@@ -38,18 +38,20 @@ const (
 func requireRedis(t *testing.T) {
 	t.Helper()
 	e2e.Require(t, e2e.Env{
-		Name:  "redis",
-		Start: "npm run e2e:redis:up",
-		Probe: e2e.DialTCP(liveAddr),
+		Name:   "redis",
+		Family: e2e.Redis,
+		Start:  "npm run e2e:redis:up",
+		Probe:  e2e.DialTCP(liveAddr),
 	})
 }
 
 func requireRedisCluster(t *testing.T) {
 	t.Helper()
 	e2e.Require(t, e2e.Env{
-		Name:  "the redis cluster",
-		Start: "npm run e2e:redis:cluster:up",
-		Probe: e2e.DialTCP(liveClusterAddr),
+		Name:   "the redis cluster",
+		Family: e2e.Redis,
+		Start:  "npm run e2e:redis:cluster:up",
+		Probe:  e2e.DialTCP(liveClusterAddr),
 	})
 }
 

--- a/internal/driver/rocketmq/live_test.go
+++ b/internal/driver/rocketmq/live_test.go
@@ -22,9 +22,10 @@ const liveNameServer = "127.0.0.1:9876"
 func liveContext(t *testing.T) context.Context {
 	t.Helper()
 	e2e.Require(t, e2e.Env{
-		Name:  "the rocketmq broker",
-		Start: "npm run e2e:up",
-		Probe: e2e.DialTCP(liveNameServer),
+		Name:   "the rocketmq broker",
+		Family: e2e.RocketMQ,
+		Start:  "npm run e2e:up",
+		Probe:  e2e.DialTCP(liveNameServer),
 	})
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	t.Cleanup(cancel)

--- a/internal/e2e/e2e.go
+++ b/internal/e2e/e2e.go
@@ -13,6 +13,8 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"sort"
+	"strings"
 	"testing"
 	"time"
 )
@@ -20,29 +22,120 @@ import (
 // OptIn is the variable a developer sets to run the live suites locally.
 const OptIn = "MQ_STUDIO_E2E"
 
+// ShardVar names the families the current run is responsible for, so CI can
+// split the live suites across jobs that each start one broker family. Unset
+// means every family, which is what a local run and any unsharded run get.
+const ShardVar = "MQ_STUDIO_E2E_FAMILIES"
+
+// NoFamilies is the value a run sets to claim nothing at all - the unit job,
+// which starts no broker. It is a word rather than the empty string on
+// purpose: an empty value is far more likely to be a variable somebody meant
+// to fill in, and silently claiming nothing is the shape of #48.
+const NoFamilies = "none"
+
+// SkipMarker prefixes every skip this gate produces. The CI coverage check
+// greps for it to tell a test no shard claimed - a sharding bug - from a test
+// that skipped itself because the broker lacks the feature it covers, which is
+// a deliberate omission and not a regression.
+const SkipMarker = "[e2e-gate]"
+
 // probeTimeout is how long an environment has to answer that it is there. It
 // is not how long the tests then give it to work.
 const probeTimeout = 2 * time.Second
+
+// Family is the broker family an environment belongs to. CI shards on it, so
+// it is also the unit in which live coverage is accounted for.
+type Family string
+
+const (
+	RocketMQ Family = "rocketmq"
+	RabbitMQ Family = "rabbitmq"
+	Kafka    Family = "kafka"
+	Pulsar   Family = "pulsar"
+	Redis    Family = "redis"
+	MQTT     Family = "mqtt"
+)
+
+// AllFamilies is the list every other place derives from - the CI shard matrix
+// included, which a test in this package pins against it. Enumerating families
+// twice is how the lists drift apart.
+var AllFamilies = []Family{RocketMQ, RabbitMQ, Kafka, Pulsar, Redis, MQTT}
 
 // Env is one broker environment a live test needs.
 type Env struct {
 	// Name reads inside a sentence: "kafka is not running".
 	Name string
+	// Family is which broker family Name belongs to. Required: a test whose
+	// environment declares none cannot be claimed by any shard, and would go
+	// unrun rather than red.
+	Family Family
 	// Start is the npm script that brings it up.
 	Start string
 	// Probe reports whether the environment is answering.
 	Probe func() error
 }
 
+// shard is the set of families this run is responsible for. A nil shard claims
+// every family: that is the unsharded case, and it keeps a local `go test` and
+// a plain `npm run test:e2e` behaving exactly as they did before sharding.
+type shard map[Family]bool
+
+func (s shard) claims(f Family) bool { return s == nil || s[f] }
+
 // verdict is what the gate decided to do with a test.
 type verdict int
 
 const (
-	run        verdict = iota
-	skipOptOut         // locally, and the developer did not ask for the live suites
-	skipAbsent         // locally, and the environment is not up
-	failAbsent         // in CI, where an absent environment is the run's problem
+	run            verdict = iota
+	skipOptOut             // locally, and the developer did not ask for the live suites
+	skipAbsent             // locally, and the environment is not up
+	skipUnclaimed          // another shard of this run owns the family
+	failAbsent             // in CI, where an absent environment is the run's problem
+	failUndeclared         // the Env named no family, so no shard can own it
 )
+
+// parseShard reads ShardVar. The zero value of set is what an unset variable
+// gives, and returns a nil shard - every family claimed.
+//
+// Every other unrecognised input is an error rather than a quiet fallback. A
+// misspelled family name that resolved to "claims nothing" would take a whole
+// suite out of CI without turning anything red, which is the defect this
+// package was written to make impossible.
+func parseShard(raw string, set bool) (shard, error) {
+	if !set {
+		return nil, nil
+	}
+	if strings.TrimSpace(raw) == "" {
+		return nil, fmt.Errorf("is set but empty; use %q to claim no families", NoFamilies)
+	}
+	if strings.TrimSpace(raw) == NoFamilies {
+		return shard{}, nil
+	}
+
+	known := make(map[Family]bool, len(AllFamilies))
+	for _, family := range AllFamilies {
+		known[family] = true
+	}
+
+	claimed := shard{}
+	for _, field := range strings.Split(raw, ",") {
+		family := Family(strings.TrimSpace(field))
+		if !known[family] {
+			return nil, fmt.Errorf("names unknown family %q; known families are %s", family, strings.Join(familyNames(), ", "))
+		}
+		claimed[family] = true
+	}
+	return claimed, nil
+}
+
+func familyNames() []string {
+	names := make([]string, 0, len(AllFamilies))
+	for _, family := range AllFamilies {
+		names = append(names, string(family))
+	}
+	sort.Strings(names)
+	return names
+}
 
 // decide is the policy, kept apart from testing.T so it can be pinned by a
 // test of its own rather than only by the CI run it governs.
@@ -54,9 +147,19 @@ const (
 // did not run. That last clause is the whole fix - reading the opt-in first is
 // what kept the app-layer suite silent in every CI run (#48).
 //
+// A shard that does not claim the family skips, which is the one skip CI
+// tolerates. It is safe only because the coverage job asserts that every test
+// passed in some shard, so a family no shard claims is still caught.
+//
 // It returns the probe's error too, so the caller reports what it saw without
 // probing a second time.
-func decide(ci bool, optIn string, probe func() error) (verdict, error) {
+func decide(ci bool, optIn string, s shard, family Family, probe func() error) (verdict, error) {
+	if family == "" {
+		return failUndeclared, nil
+	}
+	if !s.claims(family) {
+		return skipUnclaimed, nil
+	}
 	if !ci && optIn == "" {
 		return skipOptOut, nil
 	}
@@ -73,13 +176,24 @@ func decide(ci bool, optIn string, probe func() error) (verdict, error) {
 // Require skips the test when env is absent, and fails instead when CI is set.
 func Require(t *testing.T, env Env) {
 	t.Helper()
-	switch decision, err := decide(inCI(), os.Getenv(OptIn), env.Probe); decision {
+
+	raw, set := os.LookupEnv(ShardVar)
+	claimed, err := parseShard(raw, set)
+	if err != nil {
+		t.Fatalf("%s %v", ShardVar, err)
+	}
+
+	switch decision, probeErr := decide(inCI(), os.Getenv(OptIn), claimed, env.Family, env.Probe); decision {
+	case failUndeclared:
+		t.Fatalf("the %s environment declares no Family; every e2e.Env needs one or no CI shard can claim it", env.Name)
+	case skipUnclaimed:
+		t.Skipf("%s this run covers %s=%s, and %s is in the %s family", SkipMarker, ShardVar, raw, env.Name, env.Family)
 	case skipOptOut:
-		t.Skipf("set %s=1 and run `%s` to exercise %s", OptIn, env.Start, env.Name)
+		t.Skipf("%s set %s=1 and run `%s` to exercise %s", SkipMarker, OptIn, env.Start, env.Name)
 	case skipAbsent:
-		t.Skipf("%s is not running; start it with `%s` (%v)", env.Name, env.Start, err)
+		t.Skipf("%s %s is not running; start it with `%s` (%v)", SkipMarker, env.Name, env.Start, probeErr)
 	case failAbsent:
-		t.Fatalf("%s must be running in CI: %v", env.Name, err)
+		t.Fatalf("%s must be running in CI: %v", env.Name, probeErr)
 	}
 }
 

--- a/internal/e2e/e2e_test.go
+++ b/internal/e2e/e2e_test.go
@@ -2,11 +2,18 @@ package e2e
 
 import (
 	"errors"
+	"os"
+	"regexp"
+	"sort"
+	"strings"
 	"testing"
 )
 
 // The whole policy as a table. The first row is the regression this package
 // exists for: in CI, with nobody having set the opt-in, the suite runs.
+//
+// Every row claims the family it names, so these rows say what the gate did
+// before sharding existed; the shard rules get their own tables below.
 func TestDecide(t *testing.T) {
 	absent := errors.New("nothing listening")
 	up := func() error { return nil }
@@ -27,7 +34,7 @@ func TestDecide(t *testing.T) {
 		{"locally the opt-in and a live environment run", false, "1", up, run},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := decide(test.ci, test.optIn, test.probe)
+			got, err := decide(test.ci, test.optIn, nil, Kafka, test.probe)
 			if got != test.want {
 				t.Fatalf("decide = %d, want %d", got, test.want)
 			}
@@ -44,10 +51,181 @@ func TestDecideDoesNotProbeWhenOptedOut(t *testing.T) {
 	probed := 0
 	probe := func() error { probed++; return nil }
 
-	if _, _ = decide(false, "", probe); probed != 0 {
+	if _, _ = decide(false, "", nil, Kafka, probe); probed != 0 {
 		t.Fatalf("probed %d times while opted out", probed)
 	}
-	if _, _ = decide(true, "", probe); probed != 1 {
+	if _, _ = decide(true, "", nil, Kafka, probe); probed != 1 {
 		t.Fatalf("probed %d times in CI, want 1", probed)
+	}
+}
+
+// An Env with no family cannot be claimed by any shard, so it would go unrun
+// rather than red. That is the #48 shape, so it fails everywhere - in CI, and
+// locally too, where whoever added the Env is the one who can fix it.
+func TestDecideFailsAnEnvThatDeclaresNoFamily(t *testing.T) {
+	for _, ci := range []bool{true, false} {
+		got, _ := decide(ci, "1", nil, "", func() error { return nil })
+		if got != failUndeclared {
+			t.Fatalf("decide with no family in ci=%v = %d, want failUndeclared", ci, got)
+		}
+	}
+}
+
+// The family check comes first, so an unclaimed family never dials: a shard
+// that did not start RabbitMQ should not wait on RabbitMQ's port.
+func TestDecideDoesNotProbeAnUnclaimedFamily(t *testing.T) {
+	probed := 0
+	probe := func() error { probed++; return nil }
+
+	got, _ := decide(true, "1", shard{Kafka: true}, RabbitMQ, probe)
+	if got != skipUnclaimed {
+		t.Fatalf("decide = %d, want skipUnclaimed", got)
+	}
+	if probed != 0 {
+		t.Fatalf("probed %d times for an unclaimed family", probed)
+	}
+}
+
+// A claimed family in CI keeps the old rule: absent is the run's problem.
+func TestDecideStillFailsAClaimedFamilyThatIsAbsent(t *testing.T) {
+	got, err := decide(true, "", shard{Kafka: true}, Kafka, func() error { return errors.New("down") })
+	if got != failAbsent {
+		t.Fatalf("decide = %d, want failAbsent", got)
+	}
+	if err == nil {
+		t.Fatal("decide returned no error with failAbsent")
+	}
+}
+
+func TestParseShard(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		raw    string
+		set    bool
+		want   shard
+		wantOK bool
+	}{
+		{"unset claims every family", "", false, nil, true},
+		{"none claims nothing", NoFamilies, true, shard{}, true},
+		{"one family", "kafka", true, shard{Kafka: true}, true},
+		{"several families", "kafka,redis", true, shard{Kafka: true, Redis: true}, true},
+		{"surrounding space is tolerated", " kafka , redis ", true, shard{Kafka: true, Redis: true}, true},
+
+		// Both of these would take a suite out of CI without turning
+		// anything red, which is exactly what this package prevents.
+		{"set but empty is an error", "", true, nil, false},
+		{"whitespace only is an error", "   ", true, nil, false},
+		{"an unknown family is an error", "rocketmqq", true, nil, false},
+		{"one unknown family among good ones is an error", "kafka,nope", true, nil, false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := parseShard(test.raw, test.set)
+			if (err == nil) != test.wantOK {
+				t.Fatalf("parseShard(%q, %v) err = %v, want ok = %v", test.raw, test.set, err, test.wantOK)
+			}
+			if !test.wantOK {
+				return
+			}
+			if (got == nil) != (test.want == nil) {
+				t.Fatalf("parseShard(%q) = %v, want %v", test.raw, got, test.want)
+			}
+			for _, family := range AllFamilies {
+				if got.claims(family) != test.want.claims(family) {
+					t.Fatalf("parseShard(%q).claims(%s) = %v, want %v", test.raw, family, got.claims(family), test.want.claims(family))
+				}
+			}
+		})
+	}
+}
+
+// A nil shard is the unsharded case, and has to claim everything or a local
+// run would stop exercising the live suites.
+func TestNilShardClaimsEveryFamily(t *testing.T) {
+	var unsharded shard
+	for _, family := range AllFamilies {
+		if !unsharded.claims(family) {
+			t.Fatalf("the unsharded case does not claim %s", family)
+		}
+	}
+}
+
+// The CI shard matrix and AllFamilies are two lists of the same thing, and
+// two lists drift. This is the one that matters: a family with no shard is a
+// family whose live tests skip in every job of the run, which is #48 again.
+// The coverage job would catch it after the fact; this catches it in review.
+func TestEveryFamilyHasACIShard(t *testing.T) {
+	const workflow = "../../.github/workflows/ci.yml"
+
+	source, err := os.ReadFile(workflow)
+	if err != nil {
+		t.Fatalf("reading %s: %v", workflow, err)
+	}
+
+	// The matrix spells one family per line as `- family: <name>`. Matching
+	// the line rather than parsing YAML keeps this test off the dependency
+	// list; the format is pinned by the failure message below.
+	pattern := regexp.MustCompile(`(?m)^\s*-\s*family:\s*([a-z]+)\s*$`)
+	matches := pattern.FindAllSubmatch(source, -1)
+	if len(matches) == 0 {
+		t.Fatalf("found no `- family: <name>` entries in %s; the shard matrix moved and this guard needs to follow it", workflow)
+	}
+
+	sharded := map[string]bool{}
+	for _, match := range matches {
+		sharded[string(match[1])] = true
+	}
+
+	declared := map[string]bool{}
+	for _, family := range AllFamilies {
+		declared[string(family)] = true
+	}
+
+	var missing, unknown []string
+	for family := range declared {
+		if !sharded[family] {
+			missing = append(missing, family)
+		}
+	}
+	for family := range sharded {
+		if !declared[family] {
+			unknown = append(unknown, family)
+		}
+	}
+	sort.Strings(missing)
+	sort.Strings(unknown)
+
+	if len(missing) > 0 {
+		t.Errorf("families with no shard in %s: %v - their live tests would skip in every job", workflow, missing)
+	}
+	if len(unknown) > 0 {
+		t.Errorf("shards in %s for families this package does not declare: %v", workflow, unknown)
+	}
+}
+
+// The CI coverage check greps skip output for SkipMarker to tell a test no
+// shard claimed from a test that skipped itself. A gate skip that forgot the
+// marker would read as a deliberate omission and stop being accounted for, so
+// the marker is pinned here rather than left to review.
+func TestEveryGateSkipCarriesTheMarker(t *testing.T) {
+	source, err := os.ReadFile("e2e.go")
+	if err != nil {
+		t.Fatalf("reading e2e.go: %v", err)
+	}
+
+	// Require only. Missing's skip is local-only - in CI it is a failure - so
+	// it never reaches the coverage check and needs no marker.
+	body := regexp.MustCompile(`(?s)func Require\(.*?\n\}`).FindString(string(source))
+	if body == "" {
+		t.Fatal("could not find func Require in e2e.go; this guard needs to follow it")
+	}
+
+	skips := regexp.MustCompile(`t\.Skipf?\([^\n]*`).FindAllString(body, -1)
+	if len(skips) == 0 {
+		t.Fatal("found no t.Skip calls in Require; this guard needs to follow them")
+	}
+	for _, skip := range skips {
+		if !strings.Contains(skip, "SkipMarker") {
+			t.Errorf("gate skip without SkipMarker: %s", skip)
+		}
 	}
 }

--- a/scripts/ci-coverage.mjs
+++ b/scripts/ci-coverage.mjs
@@ -1,0 +1,117 @@
+// Proves that the sharded CI run exercised everything an unsharded run would.
+//
+// Splitting the live suites across one job per broker family means a test can
+// now go unrun without anything turning red: every shard it is not claimed by
+// skips it, and a family no shard claims is skipped by all of them. That is
+// the shape of issue #48, where the whole app-layer suite skipped every CI run
+// and asserted nothing for weeks.
+//
+// So the shards do not gate on their own. This does, over their combined
+// `go test -json` output:
+//
+//   every test must have passed in at least one shard, unless it skipped
+//   itself for a reason of its own.
+//
+// The distinction is what e2e.SkipMarker is for. A skip carrying the marker
+// came from the gate - no shard claimed the family, or the broker was absent -
+// and does not count as coverage. A skip without it came from the test body
+// ("this broker runs plain_acl, not 5.3 authentication"), which is a
+// deliberate omission an unsharded run would make too.
+//
+// Usage: node scripts/ci-coverage.mjs <directory of results-*.json>
+
+import { readdir, readFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+
+const SKIP_MARKER = '[e2e-gate]'
+
+// The unit job runs `go test ./...` with no broker, so its output is the only
+// one that names every test in the repository. Without it the inventory would
+// be whatever the shards happened to cover, which cannot catch a dropped one.
+const INVENTORY = 'results-unit.json'
+
+const directory = process.argv[2]
+if (!directory) {
+  console.error('usage: node scripts/ci-coverage.mjs <directory of results-*.json>')
+  process.exit(2)
+}
+
+const files = (await readdir(directory)).filter((name) => name.endsWith('.json')).sort()
+if (!files.includes(INVENTORY)) {
+  console.error(`${INVENTORY} is missing from ${directory}: without it there is no full test inventory to check the shards against.`)
+  console.error(`found: ${files.join(', ') || '(nothing)'}`)
+  process.exit(1)
+}
+
+/** One row per test, accumulated across every shard. */
+const tests = new Map()
+
+function row(key) {
+  if (!tests.has(key)) {
+    tests.set(key, { passedIn: [], skippedIn: [], failedIn: [], ownSkip: false })
+  }
+  return tests.get(key)
+}
+
+for (const file of files) {
+  const shard = file.replace(/^results-/, '').replace(/\.json$/, '')
+  const content = await readFile(resolve(directory, file), 'utf8')
+
+  // Output events arrive before the pass/skip/fail that closes a test, so the
+  // marker has to be remembered until the verdict lands.
+  const markers = new Set()
+
+  for (const line of content.split('\n')) {
+    if (!line.trim()) continue
+
+    let event
+    try {
+      event = JSON.parse(line)
+    } catch {
+      // `go test -json` interleaves build errors as plain text. A build
+      // failure already fails its own shard, so skipping the line here loses
+      // nothing this check is responsible for.
+      continue
+    }
+    if (!event.Test) continue
+
+    const key = `${event.Package}.${event.Test}`
+    if (event.Action === 'output' && event.Output?.includes(SKIP_MARKER)) {
+      markers.add(key)
+      continue
+    }
+    if (event.Action === 'pass') row(key).passedIn.push(shard)
+    else if (event.Action === 'fail') row(key).failedIn.push(shard)
+    else if (event.Action === 'skip') {
+      row(key).skippedIn.push(shard)
+      if (!markers.has(key)) row(key).ownSkip = true
+    }
+  }
+}
+
+const unrun = []
+const failed = []
+for (const [key, result] of tests) {
+  if (result.failedIn.length > 0) failed.push({ key, ...result })
+  else if (result.passedIn.length === 0 && !result.ownSkip) unrun.push({ key, ...result })
+}
+
+const covered = tests.size - unrun.length - failed.length
+console.log(`shards: ${files.map((f) => f.replace(/^results-|\.json$/g, '')).join(', ')}`)
+console.log(`tests seen: ${tests.size}`)
+console.log(`covered:    ${covered}`)
+
+if (failed.length > 0) {
+  console.error(`\n${failed.length} test(s) failed:`)
+  for (const test of failed) console.error(`  ${test.key} (in ${test.failedIn.join(', ')})`)
+}
+
+if (unrun.length > 0) {
+  console.error(`\n${unrun.length} test(s) ran in no shard - every skip came from the e2e gate:`)
+  for (const test of unrun) console.error(`  ${test.key} (skipped in ${test.skippedIn.join(', ') || 'no shard at all'})`)
+  console.error('\nEither no shard claims that test\'s broker family, or the family\'s')
+  console.error('environment did not come up. Both mean the sharded run asserted less')
+  console.error('than an unsharded one would. See internal/e2e/e2e.go.')
+}
+
+process.exit(failed.length > 0 || unrun.length > 0 ? 1 : 0)

--- a/scripts/e2e-pulsar-seed.sh
+++ b/scripts/e2e-pulsar-seed.sh
@@ -2,13 +2,21 @@
 #
 # Seeds the Pulsar E2E environment with a topology worth cross-checking.
 #
-# Unlike the RocketMQ seed, nothing here is required: every live test creates
-# and removes what it needs, because a suite that depends on a seed fails
-# differently depending on whether somebody ran it. What this is for is the
-# cross-check, which compares figures the app computes against the same figures
-# from Pulsar's own CLI - and comparing zero against zero proves nothing.
+# Unlike the RocketMQ seed, nothing here is required by the live tests: every
+# one of them creates and removes what it needs, because a suite that depends
+# on a seed fails differently depending on whether somebody ran it. What this
+# is for is the cross-check, which compares figures the app computes against
+# the same figures from Pulsar's own CLI - and comparing zero against zero
+# proves nothing.
 #
-# Idempotent: run it as often as you like.
+# Every bin/pulsar-admin call is a fresh JVM, which is the whole cost of this
+# script: twenty of them in series took over two minutes of every CI run. They
+# are grouped into layers below instead - within a layer nothing depends on
+# anything else, so the layer costs one JVM start rather than one each.
+#
+# Idempotent: run it as often as you like. The message counts grow, which the
+# cross-check does not mind - it compares the app and the CLI at one moment,
+# not against a fixed number.
 set -euo pipefail
 
 CONTAINER="${PULSAR_CONTAINER:-mq-studio-e2e-pulsar-pulsar-1}"
@@ -27,56 +35,131 @@ produce() {
 }
 
 # Best effort throughout: every object may already exist from a previous run,
-# and "already exists" is success as far as seeding is concerned.
+# and "already exists" is success as far as seeding is concerned. What this
+# used to hide is that a seed which failed outright looked identical - so the
+# verification at the bottom is what now decides whether this worked.
 try() {
   "$@" >/dev/null 2>&1 || true
 }
 
+pids=()
+
+# Adds a command to the current layer. Nothing in a layer may depend on
+# anything else in it.
+spawn() {
+  try "$@" &
+  pids+=("$!")
+}
+
+# Closes the layer. try never fails, so this only waits.
+await() {
+  local pid
+  for pid in ${pids[@]+"${pids[@]}"}; do
+    wait "$pid" || true
+  done
+  pids=()
+}
+
 echo "seeding pulsar in $CONTAINER"
 
+# Layer 1-2: the tenant, then the namespace inside it.
 try admin tenants create "$TENANT" --allowed-clusters "$CLUSTER"
 try admin namespaces create "$NAMESPACE"
 
-# A namespace policy, so the namespaces page has something other than defaults
-# to show and the cross-check has a value to compare.
+# Layer 3: everything that needs only the namespace.
 #
-# A day rather than an hour, because this TTL applies to the seeded messages
-# too: a short one expires the backlog the cross-check is comparing against,
-# and the suite then fails with "no backlog" for anyone who seeded a while ago.
-try admin namespaces set-message-ttl "$NAMESPACE" --messageTTL 86400
-try admin namespaces set-retention "$NAMESPACE" --size 512M --time 60m
+# The TTL is a day rather than an hour because it applies to the seeded
+# messages too: a short one expires the backlog the cross-check is comparing
+# against, and the suite then fails with "no backlog" for anyone who seeded a
+# while ago.
+spawn admin namespaces set-message-ttl "$NAMESPACE" --messageTTL 86400
+spawn admin namespaces set-retention "$NAMESPACE" --size 512M --time 60m
+
+# A role grant, so the tokens page has a row. The role need not exist: Pulsar
+# authorises the subject of a token and keeps no directory of them.
+spawn admin namespaces grant-permission "$NAMESPACE" --role seeded-reader --actions consume
 
 # Both topic shapes. They answer at different endpoints - a non-partitioned
 # topic returns 404 from partitioned-stats - so a seed with only one of them
 # would leave half the driver uncovered.
-try admin topics create-partitioned-topic "persistent://$NAMESPACE/orders" --partitions 3
-try admin topics create "persistent://$NAMESPACE/audit"
-try admin topics create "non-persistent://$NAMESPACE/telemetry"
+spawn admin topics create-partitioned-topic "persistent://$NAMESPACE/orders" --partitions 3
+spawn admin topics create "persistent://$NAMESPACE/audit"
+spawn admin topics create "non-persistent://$NAMESPACE/telemetry"
 
 # The dead-letter naming convention, spelled out the way the client libraries
 # spell it. Nothing on the broker records the link, so the seed is what gives
 # the cross-check a source to resolve - and an orphan, whose origin topic does
 # not exist, is the row the page most needs to get right.
-try admin topics create "persistent://$NAMESPACE/orders-worker-DLQ"
-try admin topics create "persistent://$NAMESPACE/orders-worker-RETRY"
-try admin topics create "persistent://$NAMESPACE/gone-reader-DLQ"
+spawn admin topics create "persistent://$NAMESPACE/orders-worker-DLQ"
+spawn admin topics create "persistent://$NAMESPACE/orders-worker-RETRY"
+spawn admin topics create "persistent://$NAMESPACE/gone-reader-DLQ"
+await
 
-# Subscriptions created before anything is published, so every message below
-# lands in their backlog. A backlog is what the consumer page is read for, and
-# an empty one would make the cross-check compare zero against zero.
-try admin topics create-subscription "persistent://$NAMESPACE/orders" -s worker
-try admin topics create-subscription "persistent://$NAMESPACE/orders" -s archive
-try admin topics create-subscription "persistent://$NAMESPACE/audit" -s slow
-try admin topics create-subscription "persistent://$NAMESPACE/orders-worker-DLQ" -s cleanup
+# Layer 4: subscriptions, created before anything is published so every message
+# below lands in their backlog. A backlog is what the consumer page is read
+# for, and an empty one would make the cross-check compare zero against zero.
+spawn admin topics create-subscription "persistent://$NAMESPACE/orders" -s worker
+spawn admin topics create-subscription "persistent://$NAMESPACE/orders" -s archive
+spawn admin topics create-subscription "persistent://$NAMESPACE/audit" -s slow
+spawn admin topics create-subscription "persistent://$NAMESPACE/orders-worker-DLQ" -s cleanup
+await
 
-# Nothing consumes these, so they stay in the backlog.
-try produce "persistent://$NAMESPACE/orders" "seeded" 5
-try produce "persistent://$NAMESPACE/audit" "audited" 2
-try produce "persistent://$NAMESPACE/orders-worker-DLQ" "gave-up" 3
+# Layer 5: nothing consumes these, so they stay in the backlog.
+spawn produce "persistent://$NAMESPACE/orders" "seeded" 5
+spawn produce "persistent://$NAMESPACE/audit" "audited" 2
+spawn produce "persistent://$NAMESPACE/orders-worker-DLQ" "gave-up" 3
+await
 
-# A role grant, so the tokens page has a row. The role need not exist: Pulsar
-# authorises the subject of a token and keeps no directory of them.
-try admin namespaces grant-permission "$NAMESPACE" --role seeded-reader --actions consume
+# Verification. Everything above swallows its errors, so without this a seed
+# that did nothing at all looks exactly like one that worked - and the
+# cross-check would then fail somewhere far from the cause, or worse, pass by
+# comparing two zeroes.
+fail() {
+  echo "pulsar seed verification failed: $1" >&2
+  echo "the cross-check reads this topology, so it would fail further from the cause." >&2
+  exit 1
+}
+
+echo "verifying"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+# One layer again: these four reads do not depend on each other, and in series
+# they would cost more JVM starts than the seeding above.
+admin namespaces list "$TENANT" >"$tmp/namespaces" 2>/dev/null &
+admin topics stats "persistent://$NAMESPACE/audit" >"$tmp/audit" 2>/dev/null &
+admin topics partitioned-stats "persistent://$NAMESPACE/orders" >"$tmp/orders" 2>/dev/null &
+admin topics list "$NAMESPACE" >"$tmp/topics" 2>/dev/null &
+wait || true
+
+grep -qE "^${NAMESPACE}[[:space:]]*$" "$tmp/namespaces" \
+  || fail "namespace $NAMESPACE is not there"
+
+[ -s "$tmp/audit" ] \
+  || fail "the non-partitioned topic persistent://$NAMESPACE/audit is not there"
+
+for subscription in worker archive; do
+  grep -q "\"$subscription\"" "$tmp/orders" \
+    || fail "subscription $subscription is missing from persistent://$NAMESPACE/orders"
+done
+
+# The one figure the cross-check cannot do without: comparing an empty backlog
+# against an empty backlog would pass whatever the driver did. Publishing is
+# asynchronous, so a first look that finds nothing gets a few more.
+backlog_present() {
+  grep -qE '"msgBacklog"[[:space:]]*:[[:space:]]*[1-9]' "$tmp/orders"
+}
+
+for _ in 1 2 3 4 5; do
+  if backlog_present; then
+    break
+  fi
+  sleep 2
+  admin topics partitioned-stats "persistent://$NAMESPACE/orders" >"$tmp/orders" 2>/dev/null || true
+done
+backlog_present \
+  || fail "persistent://$NAMESPACE/orders has an empty backlog; the cross-check would compare zero against zero"
 
 echo "seeded: $NAMESPACE"
-admin topics list "$NAMESPACE" || true
+cat "$tmp/topics"

--- a/scripts/e2e-seed.sh
+++ b/scripts/e2e-seed.sh
@@ -25,6 +25,9 @@ NAMESPACE="${MQ_STUDIO_E2E_NAMESPACE:-NS_E2E}"
 NS_TOPIC="${MQ_STUDIO_E2E_NS_TOPIC:-MQ_STUDIO_E2E_NS}"
 NS_GROUP="${MQ_STUDIO_E2E_NS_GROUP:-MQ_STUDIO_E2E_NS_GROUP}"
 
+ATTEMPTS="${MQ_STUDIO_E2E_SEED_ATTEMPTS:-30}"
+DELAY="${MQ_STUDIO_E2E_SEED_DELAY:-2}"
+
 if ! docker inspect "$CONTAINER" >/dev/null 2>&1; then
   echo "broker container '$CONTAINER' is not running; start it with: npm run e2e:up" >&2
   exit 1
@@ -32,19 +35,56 @@ fi
 
 run() { docker exec "$CONTAINER" sh -c "$1"; }
 
+# mqadmin exits 0 even when its command threw, so `set -e` never sees the
+# failure and the stack trace it prints is the only signal there is. Retried
+# because compose reports the broker healthy before its listener accepts: the
+# calls that land in that window fail with RemotingConnectException, and the
+# first resource is simply absent while the seed goes on to print "seeded".
+attempt() {
+  local label="$1" command="$2" output
+  echo "$label"
+  for _ in $(seq 1 "$ATTEMPTS"); do
+    output="$(run "$command" 2>&1 || true)"
+    case "$output" in
+      *Exception*|*"command failed"*) sleep "$DELAY" ;;
+      *) return 0 ;;
+    esac
+  done
+  echo "$output" >&2
+  echo "$label did not succeed in $ATTEMPTS attempts" >&2
+  exit 1
+}
+
 seed_topic() {
-  echo "seeding topic $1"
-  run "sh mqadmin updateTopic -n $NAMESRV -b $BROKER -t '$1' -r 4 -w 4" >/dev/null
+  attempt "seeding topic $1" "sh mqadmin updateTopic -n $NAMESRV -b $BROKER -t '$1' -r 4 -w 4"
 }
 
 seed_group() {
-  echo "seeding consumer group $1"
-  run "sh mqadmin updateSubGroup -n $NAMESRV -b $BROKER -g '$1'" >/dev/null
+  attempt "seeding consumer group $1" "sh mqadmin updateSubGroup -n $NAMESRV -b $BROKER -g '$1'"
 }
 
 seed_topic "$TOPIC"
 seed_group "$GROUP"
 seed_topic "$NAMESPACE%$NS_TOPIC"
 seed_group "$NAMESPACE%$NS_GROUP"
+
+# What the tests read is the name server, which learns a topic from the
+# broker's registration and not from the call that created it. Asserting the
+# end state is what keeps a seed that created nothing from reaching them
+# looking done - the failure this whole script existed to not have.
+missing=""
+for _ in $(seq 1 "$ATTEMPTS"); do
+  listed="$(run "sh mqadmin topicList -n $NAMESRV" 2>/dev/null || true)"
+  missing=""
+  for topic in "$TOPIC" "$NAMESPACE%$NS_TOPIC"; do
+    printf '%s\n' "$listed" | grep -qxF "$topic" || missing="$missing $topic"
+  done
+  [ -z "$missing" ] && break
+  sleep "$DELAY"
+done
+if [ -n "$missing" ]; then
+  echo "the name server does not list:$missing" >&2
+  exit 1
+fi
 
 echo "seeded: topic=$TOPIC group=$GROUP namespace=$NAMESPACE"

--- a/tests/e2e/rocketmq-acl/up.sh
+++ b/tests/e2e/rocketmq-acl/up.sh
@@ -21,4 +21,28 @@ docker compose -f compose.yaml down --remove-orphans >/dev/null 2>&1 || true
 rm -rf plain_acl.yml
 cp plain_acl.seed.yml plain_acl.yml
 
-exec docker compose -f compose.yaml up -d --wait
+docker compose -f compose.yaml up -d --wait
+
+# `--wait` returns when the container is healthy, which is earlier than the
+# broker being usable: it has still to register with the name server, and a
+# client that dials in that window is told there is no master broker at all.
+# The single serial CI job never met this - twenty minutes of starting other
+# brokers went by before anything connected - but one job per broker family
+# runs the tests seconds after this returns.
+ATTEMPTS="${MQ_STUDIO_E2E_ACL_ATTEMPTS:-30}"
+DELAY="${MQ_STUDIO_E2E_ACL_DELAY:-2}"
+NAMESRV="${MQ_STUDIO_E2E_ACL_NAMESRV:-namesrv:9876}"
+
+broker="$(docker compose -f compose.yaml ps -q broker)"
+for _ in $(seq 1 "$ATTEMPTS"); do
+  # A registered master carries broker id 0, which is the third column.
+  if docker exec "$broker" sh -c "sh mqadmin clusterList -n $NAMESRV" 2>/dev/null |
+    awk 'NR > 1 && $3 == "0" { found = 1 } END { exit !found }'; then
+    echo "acl broker registered with $NAMESRV"
+    exit 0
+  fi
+  sleep "$DELAY"
+done
+
+echo "the acl broker did not register with $NAMESRV in $ATTEMPTS attempts" >&2
+exit 1


### PR DESCRIPTION
## What

Three commits. The main one splits the single `Check` job into four kinds of job
that run at the same time, and shards the live suites one job per broker family.
The other two are a cache fix and a seed-script fix found along the way.

| | before | after |
| --- | --- | --- |
| CI jobs | `Check` (everything, in series) | `Meta`, `Frontend`, `Static checks and unit tests`, `E2E (family)` x6, `Live coverage` |
| Wall clock | 20m45s | the slowest shard |

## Why

`Check` took 20m45s, and 14m09s of that was `npm run check`. Inside it,
`go test ./...` spent 6m48s on `internal/app` while five of the six broker
families it covers sat idle, and `go vet ./...` spent 3m45s recompiling the cgo
tree from cold on every run.

The work separates cleanly. The frontend needs neither Go nor Docker nor the GTK
headers, and used to wait behind all three. The static checks are the only thing
that needs them — `internal/bridge` and `internal/tray` are the only packages
that import wails; nothing under `internal/app` or `internal/driver` reaches it.
Each live suite only needs its own compose stacks.

## How

Sharding is not free, and the risk it introduces is the same shape as
[#48](https://github.com/amigoer/mq-studio/issues/48): `MQ_STUDIO_E2E_FAMILIES`
names the families a shard is responsible for and the rest skip, so a family no
shard claims would skip in every job of the run and **nothing would turn red**.
Three things close that:

- every `e2e.Env` now declares a `Family`, and one that declares none is a hard
  failure rather than a test no shard can claim;
- `TestEveryFamilyHasACIShard` pins `e2e.AllFamilies` against the shard matrix in
  the workflow, so the two lists cannot drift apart;
- `scripts/ci-coverage.mjs` asserts, over every shard's `go test -json` output,
  that each test passed in at least one of them. `e2e.SkipMarker` is what lets it
  tell a skip the gate produced from a test that skipped itself — the latter is a
  deliberate omission an unsharded run makes too.

`Package` waits on the coverage job as well as the shards, so an artifact is
never produced from a run that quietly tested less than it should.

### `ci(package): stop caching go builds in the matrix`

Six matrix jobs each saved about a gigabyte of Go cache on every push to `main`,
which took the repository past the 10 GB Actions cache limit and evicted the one
cache that pays off. `ci.yml`'s `setup-go` logged "Cache is not found" on every
run and then saved a fresh copy for the next run to lose. Each packaging target
builds once on a runner of its own and reuses nothing, so the matrix gives up
almost nothing by dropping it.

### `test(pulsar): make a failed seed fail loudly`

Every call in `scripts/e2e-pulsar-seed.sh` was wrapped in a `try` that swallowed
its error. Pointed at a container that does not exist, the script printed
"seeded" and exited 0 — and the cross-check that reads this topology then passed
by comparing two zeroes. It now verifies the namespace, both topic shapes, the
subscriptions and a non-empty backlog, and names whichever is missing.

The calls are also grouped into layers rather than twenty serial `pulsar-admin`
invocations, each a fresh JVM. That buys less than it looks like it should — the
container saturates, and both versions time at about 53 seconds locally. The
verification is the part worth having.

## Testing

The sharded pass-set was diffed against a full serial run over the same brokers:
**1230 tests, no difference in either direction.** Dropping one shard from that
comparison flags exactly the 14 tests it covered.

## Note for review

This removes the composite `npm run check` from CI — the pieces are split across
`meta`, `frontend` and `static`. `meta` runs `check:version` directly. Worth
deciding separately whether `check:refs` (added in
[#64](https://github.com/amigoer/mq-studio/pull/64)) should join it; it would
need `fetch-depth: 0` on that job to assert anything rather than skip.
