### PR TITLE
fix(e2e): make the rocketmq environment ready before tests run

### DIFF
--- a/scripts/e2e-seed.sh
+++ b/scripts/e2e-seed.sh
@@ -25,6 +25,9 @@ NAMESPACE="${MQ_STUDIO_E2E_NAMESPACE:-NS_E2E}"
 NS_TOPIC="${MQ_STUDIO_E2E_NS_TOPIC:-MQ_STUDIO_E2E_NS}"
 NS_GROUP="${MQ_STUDIO_E2E_NS_GROUP:-MQ_STUDIO_E2E_NS_GROUP}"
 
+ATTEMPTS="${MQ_STUDIO_E2E_SEED_ATTEMPTS:-30}"
+DELAY="${MQ_STUDIO_E2E_SEED_DELAY:-2}"
+
 if ! docker inspect "$CONTAINER" >/dev/null 2>&1; then
   echo "broker container '$CONTAINER' is not running; start it with: npm run e2e:up" >&2
   exit 1
@@ -32,19 +35,56 @@ fi
 
 run() { docker exec "$CONTAINER" sh -c "$1"; }
 
+# mqadmin exits 0 even when its command threw, so `set -e` never sees the
+# failure and the stack trace it prints is the only signal there is. Retried
+# because compose reports the broker healthy before its listener accepts: the
+# calls that land in that window fail with RemotingConnectException, and the
+# first resource is simply absent while the seed goes on to print "seeded".
+attempt() {
+  local label="$1" command="$2" output
+  echo "$label"
+  for _ in $(seq 1 "$ATTEMPTS"); do
+    output="$(run "$command" 2>&1 || true)"
+    case "$output" in
+      *Exception*|*"command failed"*) sleep "$DELAY" ;;
+      *) return 0 ;;
+    esac
+  done
+  echo "$output" >&2
+  echo "$label did not succeed in $ATTEMPTS attempts" >&2
+  exit 1
+}
+
 seed_topic() {
-  echo "seeding topic $1"
-  run "sh mqadmin updateTopic -n $NAMESRV -b $BROKER -t '$1' -r 4 -w 4" >/dev/null
+  attempt "seeding topic $1" "sh mqadmin updateTopic -n $NAMESRV -b $BROKER -t '$1' -r 4 -w 4"
 }
 
 seed_group() {
-  echo "seeding consumer group $1"
-  run "sh mqadmin updateSubGroup -n $NAMESRV -b $BROKER -g '$1'" >/dev/null
+  attempt "seeding consumer group $1" "sh mqadmin updateSubGroup -n $NAMESRV -b $BROKER -g '$1'"
 }
 
 seed_topic "$TOPIC"
 seed_group "$GROUP"
 seed_topic "$NAMESPACE%$NS_TOPIC"
 seed_group "$NAMESPACE%$NS_GROUP"
+
+# What the tests read is the name server, which learns a topic from the
+# broker's registration and not from the call that created it. Asserting the
+# end state is what keeps a seed that created nothing from reaching them
+# looking done - the failure this whole script existed to not have.
+missing=""
+for _ in $(seq 1 "$ATTEMPTS"); do
+  listed="$(run "sh mqadmin topicList -n $NAMESRV" 2>/dev/null || true)"
+  missing=""
+  for topic in "$TOPIC" "$NAMESPACE%$NS_TOPIC"; do
+    printf '%s\n' "$listed" | grep -qxF "$topic" || missing="$missing $topic"
+  done
+  [ -z "$missing" ] && break
+  sleep "$DELAY"
+done
+if [ -n "$missing" ]; then
+  echo "the name server does not list:$missing" >&2
+  exit 1
+fi
 
 echo "seeded: topic=$TOPIC group=$GROUP namespace=$NAMESPACE"

--- a/tests/e2e/rocketmq-acl/up.sh
+++ b/tests/e2e/rocketmq-acl/up.sh
@@ -21,4 +21,28 @@ docker compose -f compose.yaml down --remove-orphans >/dev/null 2>&1 || true
 rm -rf plain_acl.yml
 cp plain_acl.seed.yml plain_acl.yml
 
-exec docker compose -f compose.yaml up -d --wait
+docker compose -f compose.yaml up -d --wait
+
+# `--wait` returns when the container is healthy, which is earlier than the
+# broker being usable: it has still to register with the name server, and a
+# client that dials in that window is told there is no master broker at all.
+# The single serial CI job never met this - twenty minutes of starting other
+# brokers went by before anything connected - but one job per broker family
+# runs the tests seconds after this returns.
+ATTEMPTS="${MQ_STUDIO_E2E_ACL_ATTEMPTS:-30}"
+DELAY="${MQ_STUDIO_E2E_ACL_DELAY:-2}"
+NAMESRV="${MQ_STUDIO_E2E_ACL_NAMESRV:-namesrv:9876}"
+
+broker="$(docker compose -f compose.yaml ps -q broker)"
+for _ in $(seq 1 "$ATTEMPTS"); do
+  # A registered master carries broker id 0, which is the third column.
+  if docker exec "$broker" sh -c "sh mqadmin clusterList -n $NAMESRV" 2>/dev/null |
+    awk 'NR > 1 && $3 == "0" { found = 1 } END { exit !found }'; then
+    echo "acl broker registered with $NAMESRV"
+    exit 0
+  fi
+  sleep "$DELAY"
+done
+
+echo "the acl broker did not register with $NAMESRV in $ATTEMPTS attempts" >&2
+exit 1


### PR DESCRIPTION
## What

`scripts/e2e-seed.sh` reported success while creating nothing. Calls now retry
until their output carries no stack trace, and the script ends by asserting the
name server lists both topics, naming whichever is missing.

**This is what has had `main` red since the namespace work merged.**

## Why

Three things line up:

1. `mqadmin` **exits 0 when its command threw**, so `set -euo pipefail` never saw
   a failure.
2. The script sent its output to `/dev/null`, so the stack trace went nowhere.
3. Compose reports the broker healthy **before its listener on 10911 accepts**.

So the first `updateTopic` lost that race and the script went on to print
`seeded:` with `MQ_STUDIO_E2E` absent. On a slower cold start it is not only the
first call that lands in the window — locally, both topics were lost.

The error was there the whole time, in the CI log nobody had reason to read:

```
seeding topic MQ_STUDIO_E2E
org.apache.rocketmq.tools.command.SubCommandException: UpdateTopicSubCommand command failed
Caused by: org.apache.rocketmq.remoting.exception.RemotingConnectException: connect to broker:10911 failed
...
seeded: topic=MQ_STUDIO_E2E group=MQ_STUDIO_E2E_GROUP namespace=NS_E2E
```

## How this surfaced

`TestLiveNamespaceScopesTheTopicList` is the first test to assert the *unscoped*
fixture is present, rather than use it and get a lazily created one. It arrived
with the namespace work, and `main` has failed on it ever since — always with
the same value:

```
live_test.go:193: an unscoped connection must still see the cluster whole;
                  got [NS_E2E%MQ_STUDIO_E2E_NS broker-a]
```

The namespaced pair, created seconds later once the broker was up, and the
broker's own topic. The unscoped one never existed.

| run | result |
| --- | --- |
| `63db28a` prepare 0.0.5 — before the test existed | green |
| `e4387f8` the namespace merge — test arrives | red |
| every `main` push since | red |
| locally, isolated, on a freshly seeded cluster | reproduces first try |

The test is correct and the driver is correct. `resource.In("", name)` returns
`true` for an unscoped connection, so the namespace filter was never involved —
the topic genuinely was not on the broker.

## Testing

On a wiped cluster (`e2e:down` then `e2e:up`):

```
npm run e2e:seed        # 55s while the broker finishes coming up, both topics land
MQ_STUDIO_E2E=1 go test -count=1 ./internal/driver/rocketmq/   # ok
```

Both failure paths exit 1:

| case | output |
| --- | --- |
| broker never answers | the stack trace, then `seeding topic MQ_STUDIO_E2E did not succeed in 2 attempts` |
| creation silently does nothing | `the name server does not list: NEVER_CREATED` |
| happy path | exit 0, unchanged output |

`MQ_STUDIO_E2E_SEED_ATTEMPTS` and `MQ_STUDIO_E2E_SEED_DELAY` tune the budget;
the default is 30 x 2s.

## Note

This is the same class of bug, and the same fix, as the Pulsar seed in
[#65](https://github.com/amigoer/mq-studio/pull/65) — a seed that did nothing
looked exactly like one that worked. Worth assuming the remaining seed scripts
have it too.

---

# Second commit: `fix(e2e): wait for the acl broker to register`

Same root shape, different script, and the one the sharding actually needs.

`docker compose up -d --wait` returns when the container is **healthy**, which
is earlier than the broker being **usable** — it has still to register with the
name server. A client that dials in that window is told there is no master
broker at all rather than being made to wait:

```
live_test.go:637:  AccessEnabled: 未找到可用的 Master Broker
live_test.go:736:  refused for the wrong reason, wanted "No acl config": 未找到可用的 Master Broker
live_test.go:736:  refused for the wrong reason, wanted "signature": 未找到可用的 Master Broker
live_test.go:1275: DirectoryEnabled: 未找到可用的 Master Broker
```

Nothing noticed while CI was one serial job — twenty minutes of starting the
other five families went by between `tests/e2e/rocketmq-acl/up.sh` and the first
client. One job per family runs the suite seconds later. `internal/app` is
`ok ... 293.641s` on `main`'s serial run and fails these four under sharding.

`up.sh` now polls `clusterList` until a row carries broker id 0.

| local run | result |
| --- | --- |
| ACL suite with no pause after `up.sh`, before the gate | 4 failures |
| same, with the gate (`up.sh` takes 53s) | `ok` |
| same, 45s after `up.sh`, either way | `ok` |

That last row is what pins it as readiness rather than anything the tests do.
A name server that never reports a master exits 1 with
`the acl broker did not register with ... in N attempts`.
