### PR TITLE
ci: gate every change on the changelog naming its issues

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,44 @@
+# Asserts that the changelog names the issues the pending release closes.
+#
+# Its own workflow rather than a job in ci.yml, because of that file's
+# `paths-ignore: ['**.md']`. The fix for a failure here is an edit to
+# CHANGELOG.md, and under that filter the commit that fixes it would not start
+# a run - the pull request would sit on the failed one with no way to re-green
+# it. A gate whose own fix cannot clear it is worse than no gate.
+#
+# So it runs on everything, which it can afford to: no broker, no toolchain, no
+# node_modules. scripts/check-refs.mjs has no dependencies, and the whole job is
+# a checkout and one node process.
+#
+# release.yml runs the same script over the tag's range. This is the earlier of
+# the two, and the one that reports while the change is still being reviewed.
+name: Changelog
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: changelog-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  references:
+    name: Issue references
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      # fetch-depth: 0 is what makes this a gate rather than a skip. The script
+      # needs the tag before HEAD to know the range a release covers, and on a
+      # shallow clone it declines to assert anything rather than pretend to.
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Check the changelog names every issue closed since the last tag
+        run: npm run check:refs


### PR DESCRIPTION
## What

`check:refs` becomes a real CI gate: a new `Changelog` workflow runs it on every
push and every pull request, with `fetch-depth: 0`.

## Why

After [#64](https://github.com/amigoer/mq-studio/pull/64) the script was
reachable from two places, and neither reports at the right time:

- `npm run check` — no longer run in CI at all, now that
  [#65](https://github.com/amigoer/mq-studio/pull/65) split the check job.
- `release.yml` — reports on the day of a release, long after the change that
  forgot a reference was reviewed and merged.

## Why not a job in `ci.yml`

That was the obvious home, and it does not work. `ci.yml` ignores `**.md` on both
its `push` and `pull_request` triggers — deliberately, so a copy edit does not
spend six brokers' worth of runner minutes.

But **the fix for a failure here is an edit to `CHANGELOG.md`.** Under that
filter the commit that fixes it would not start a run, and the pull request would
sit on the failed one with no way to re-green it. A gate whose own fix cannot
clear it is worse than no gate.

GitHub has no per-job triggers, and dropping `**.md` from the filter would put
the full e2e matrix behind every documentation change. Its own workflow is the
only arrangement that leaves both properties intact — and it ends up with
*better* coverage, since it has no paths filter at all.

It can afford that: no broker, no toolchain, no `node_modules`. The script has no
dependencies and the job is a checkout plus one `node` process.

## `fetch-depth: 0`

Load-bearing. The script needs the tag before `HEAD` to know the range a release
covers; on a shallow clone it declines to assert anything rather than pretend to.
Every other checkout in this repository is shallow, which is exactly why wiring
the script into one of them would have produced a gate that silently skips.

## Testing

On a full clone of `main`:

```
node scripts/check-refs.mjs
changelog references: v0.0.5..HEAD closes #61 - named in both changelogs
  also named, with no commit footer behind them: #63
```

With a throwaway commit carrying `Closes #99` and no matching changelog entry:

```
changelog references: v0.0.5..HEAD, 2 issues closed, 1 named

1 issue closed in v0.0.5..HEAD is not named in the changelog:

  #99   2ec51c7  test: a change that answers an issue

Missing from CHANGELOG.md [Unreleased] and CHANGELOG.zh-CN.md [未发布].
...
```

exit 1, and the counts are right — `#61` is named, `#99` is not.
