### PR TITLE
ci: clear the toolchain and node 20 annotations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - uses: actions/setup-go@v6
+        id: go
         with:
           go-version-file: go.mod
           cache-dependency-path: go.sum
@@ -137,12 +138,21 @@ jobs:
           set -eu
           echo "version=$(awk '/github.com\/wailsapp\/wails\/v3/ { print $2; exit }' go.mod)" >> "$GITHUB_OUTPUT"
 
+      # Keyed on the Go version as well as the CLI's own.
+      #
+      # wails3 parses this module's source to generate the bindings, using the
+      # go/packages copy compiled into it - so a CLI built by an older Go
+      # cannot read a package that declares a newer one. Raising the go
+      # directive to 1.26 left a 1.25-built binary in the cache, and every
+      # package in the repository came back as "requires newer Go version":
+      # ten annotations on a job that still passed, and a drift check reading
+      # source it admitted it might not understand.
       - name: Cache the Wails CLI
         id: wails-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/go/bin/wails3
-          key: wails3-${{ runner.os }}-${{ steps.wails.outputs.version }}
+          key: wails3-${{ runner.os }}-${{ steps.wails.outputs.version }}-go${{ steps.go.outputs.go-version }}
 
       - name: Install the Wails CLI
         if: steps.wails-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,7 +190,7 @@ jobs:
 
       - name: Upload the unit results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: results-unit
           path: results-unit.json
@@ -322,7 +322,7 @@ jobs:
 
       - name: Upload the ${{ matrix.family }} results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: results-${{ matrix.family }}
           path: results-${{ matrix.family }}.json
@@ -341,7 +341,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Download every shard's results
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: results-*
           path: results


### PR DESCRIPTION
## What

Clears the 10 errors and 9 warnings the last run left as annotations. Two
unrelated causes, one commit each.

## Why

**The errors were a stale cache, and the noise was the smaller half.** The Wails
CLI is installed once and cached under a key that names the CLI's own version
and nothing else:

```
key: wails3-${{ runner.os }}-${{ steps.wails.outputs.version }}
```

Raising the go directive to 1.26 for the NATS driver left a binary built by Go
1.25 in that cache. `wails3` parses this module's source with the `go/packages`
copy compiled into it, and that copy cannot read a package declaring a newer
language version, so every package in the repository came back as `requires
newer Go version go1.26 (application built with go1.25)` — with this above it:

```
This application uses version go1.25 of the source-processing packages but runs
version go1.26 of 'go list'. It may fail to process source files that rely on
newer language features.
```

That is what makes it worth fixing rather than muting. `check:bindings`
regenerates the bindings with that CLI and compares, so the drift check was
reading source it had just said it might not understand — and passing.

**The warnings were four stragglers.** `release.yml` and `package.yml` are
already on `upload-artifact@v7` and `download-artifact@v8`; `ci.yml` was the
only file left on `@v4`, which the runner now forces onto Node 24 and warns
about on all eight jobs it appears in.

## How

The cache key gains the Go version, so a toolchain bump rebuilds the CLI the
same way a Wails bump already does. `actions/setup-go` gets an `id` to read
`go-version` from.

The artifact actions move to the majors the rest of the repository uses, and
`actions/cache` to v6. The options are unchanged: the coverage job's `pattern`
and `merge-multiple` are the same two `release.yml` has been passing to v8.

## Testing

Not reproducible locally — a cache key and an action major are only exercised on
a runner. What this PR's own run has to show is the `Static checks and unit
tests` job with no annotations, and the `Install the Wails CLI` step doing real
work rather than restoring from cache, because the key it looks for no longer
exists.

## Related

Follows #70, which is where the go directive moved to 1.26.
