### PR TITLE
docs: add issue and pr templates, guide, and label set

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yml
@@ -1,0 +1,108 @@
+name: "\U0001F41E Bug report"
+description: Something in the app behaves differently from what it should
+labels: ["type:bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        中文用户请改用 **Bug 反馈** 模板。
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before you start
+      options:
+        - label: I searched the [open and closed issues](https://github.com/amigoer/mq-studio/issues?q=is%3Aissue) and this is not one of them
+          required: true
+        - label: It still happens on the [latest release](https://github.com/amigoer/mq-studio/releases/latest)
+          required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: MQ Studio version
+      description: Settings → About shows it.
+      placeholder: 0.0.6
+    validations:
+      required: true
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - macOS (Apple silicon)
+        - macOS (Intel)
+        - Windows
+        - Linux
+    validations:
+      required: true
+
+  - type: dropdown
+    id: driver
+    attributes:
+      label: Which broker
+      description: >
+        The driver the bug shows up under. Choose "Not broker-specific" for the
+        window, settings, the connection list, or updating the app.
+      options:
+        - Not broker-specific
+        - RocketMQ
+        - Kafka
+        - RabbitMQ
+        - Pulsar
+        - Redis Stream
+        - NATS
+        - MQTT
+    validations:
+      required: true
+
+  - type: input
+    id: broker-version
+    attributes:
+      label: Broker version and how it runs
+      description: Leave empty if the bug is not broker-specific.
+      placeholder: RocketMQ 5.3.1, single node in Docker
+
+  - type: textarea
+    id: what
+    attributes:
+      label: What happened
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What you expected instead
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: From opening the app to the point it goes wrong.
+      value: |
+        1.
+        2.
+        3.
+    validations:
+      required: true
+
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Screenshots, and any error the app showed
+      description: >
+        Paste error text as text where you can, rather than a picture of it.
+        Redact hosts, keys and anything else you cannot share — the report is
+        public.
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Anything else
+      description: >
+        Whether it started after an update, whether a second connection is
+        fine, whether it comes and goes.

--- a/.github/ISSUE_TEMPLATE/2-bug-report.zh-CN.yml
+++ b/.github/ISSUE_TEMPLATE/2-bug-report.zh-CN.yml
@@ -1,0 +1,104 @@
+name: "\U0001F41E Bug 反馈"
+description: 应用的行为和预期不一致
+labels: ["type:bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        English speakers please use the **Bug report** template instead.
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: 提交之前
+      options:
+        - label: 我搜索过[已有的 issue](https://github.com/amigoer/mq-studio/issues?q=is%3Aissue)（含已关闭的），没有找到相同的问题
+          required: true
+        - label: 在[最新版本](https://github.com/amigoer/mq-studio/releases/latest)上问题依然存在
+          required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: MQ Studio 版本
+      description: 在「设置 → 关于」里可以看到。
+      placeholder: 0.0.6
+    validations:
+      required: true
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: 操作系统
+      options:
+        - macOS（Apple 芯片）
+        - macOS（Intel）
+        - Windows
+        - Linux
+    validations:
+      required: true
+
+  - type: dropdown
+    id: driver
+    attributes:
+      label: 涉及哪个消息队列
+      description: >
+        问题出现在哪个驱动下。窗口、设置、连接列表、软件更新这类问题请选「与具体消息队列无关」。
+      options:
+        - 与具体消息队列无关
+        - RocketMQ
+        - Kafka
+        - RabbitMQ
+        - Pulsar
+        - Redis Stream
+        - NATS
+        - MQTT
+    validations:
+      required: true
+
+  - type: input
+    id: broker-version
+    attributes:
+      label: 服务端版本与部署方式
+      description: 与具体消息队列无关的问题可以留空。
+      placeholder: RocketMQ 5.3.1，Docker 单节点
+
+  - type: textarea
+    id: what
+    attributes:
+      label: 实际发生了什么
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: 你期望的结果是什么
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: 复现步骤
+      description: 从打开应用写到出问题的那一步。
+      value: |
+        1.
+        2.
+        3.
+    validations:
+      required: true
+
+  - type: textarea
+    id: evidence
+    attributes:
+      label: 截图，以及应用给出的报错
+      description: >
+        报错尽量以文字粘贴，不要只截图。issue 是公开的，地址、密钥等不便公开的信息请先打码。
+
+  - type: textarea
+    id: context
+    attributes:
+      label: 其他补充
+      description: >
+        比如是不是升级之后才出现的、换一个连接是否正常、是否偶发。

--- a/.github/ISSUE_TEMPLATE/3-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/3-feature-request.yml
@@ -1,0 +1,80 @@
+name: "\U00002728 Feature request"
+description: Something the app should be able to do and cannot
+labels: ["type:feature"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        中文用户请改用 **功能建议** 模板。
+
+        Asking for a broker MQ Studio does not connect to yet is the
+        **Driver request** template instead.
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before you start
+      options:
+        - label: I searched the [open and closed issues](https://github.com/amigoer/mq-studio/issues?q=is%3Aissue) and this is not one of them
+          required: true
+        - label: I checked the [roadmap](https://github.com/amigoer/mq-studio/blob/main/docs/ROADMAP.md)
+          required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Which part of the app
+      options:
+        - Connections
+        - Topics, queues and exchanges
+        - Messages — query, browse, produce, dead letters
+        - Consumers — groups, lag, offsets
+        - Cluster, metrics and alerts
+        - Administration — access control, users, quotas, policies
+        - The app itself — window, settings, updates, languages
+        - Something else
+    validations:
+      required: true
+
+  - type: dropdown
+    id: driver
+    attributes:
+      label: Which broker
+      description: Whether this is one family's concept or something every connection should have.
+      options:
+        - Every broker
+        - RocketMQ
+        - Kafka
+        - RabbitMQ
+        - Pulsar
+        - Redis Stream
+        - NATS
+        - MQTT
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What you are trying to do
+      description: >
+        The task, and where the app leaves you today. What you do instead —
+        a CLI, the broker's own console, a script — is the useful part here.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: What you would like
+      description: Where it would live in the app, and what it would show or do.
+    validations:
+      required: true
+
+  - type: textarea
+    id: prior-art
+    attributes:
+      label: How other tools do it
+      description: >
+        A screenshot or a link to the same thing in another client or console,
+        if one has it.

--- a/.github/ISSUE_TEMPLATE/4-feature-request.zh-CN.yml
+++ b/.github/ISSUE_TEMPLATE/4-feature-request.zh-CN.yml
@@ -1,0 +1,77 @@
+name: "\U00002728 功能建议"
+description: 希望应用支持、但目前做不到的事
+labels: ["type:feature"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        English speakers please use the **Feature request** template instead.
+
+        希望支持一个目前连不上的消息队列，请改用 **驱动支持请求** 模板。
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: 提交之前
+      options:
+        - label: 我搜索过[已有的 issue](https://github.com/amigoer/mq-studio/issues?q=is%3Aissue)（含已关闭的），没有找到相同的建议
+          required: true
+        - label: 我看过[开发计划](https://github.com/amigoer/mq-studio/blob/main/docs/ROADMAP.zh-CN.md)
+          required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: 涉及应用的哪一部分
+      options:
+        - 连接管理
+        - 主题、队列与交换机
+        - 消息 —— 查询、浏览、发送、死信
+        - 消费者 —— 消费组、堆积、位点
+        - 集群、指标与告警
+        - 管理 —— 权限、用户、配额、策略
+        - 应用本体 —— 窗口、设置、更新、语言
+        - 其他
+    validations:
+      required: true
+
+  - type: dropdown
+    id: driver
+    attributes:
+      label: 涉及哪个消息队列
+      description: 这是某一个家族特有的概念，还是所有连接都该有的能力。
+      options:
+        - 所有消息队列
+        - RocketMQ
+        - Kafka
+        - RabbitMQ
+        - Pulsar
+        - Redis Stream
+        - NATS
+        - MQTT
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: 你想完成的事情是什么
+      description: >
+        具体的场景，以及现在卡在哪一步。现在改用什么方式绕过去（命令行、服务端自带的控制台、脚本），
+        这一段信息价值最大。
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: 你希望它做成什么样
+      description: 大概放在应用的哪个位置，展示什么、能操作什么。
+    validations:
+      required: true
+
+  - type: textarea
+    id: prior-art
+    attributes:
+      label: 其他工具是怎么做的
+      description: 如果别的客户端或控制台有类似功能，附一张截图或链接。

--- a/.github/ISSUE_TEMPLATE/5-driver-request.yml
+++ b/.github/ISSUE_TEMPLATE/5-driver-request.yml
@@ -1,0 +1,103 @@
+name: "\U0001F50C Driver request"
+description: A broker MQ Studio does not connect to yet
+labels: ["type:driver"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        中文用户请改用 **驱动支持请求** 模板。
+
+        Drivers land one at a time and each is taken to the same depth before
+        the next one starts — the [roadmap](https://github.com/amigoer/mq-studio/blob/main/docs/ROADMAP.md)
+        has the order. What moves a family up that list is knowing there are
+        people running it, and knowing what the app would have to talk to.
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before you start
+      options:
+        - label: I searched the [open and closed issues](https://github.com/amigoer/mq-studio/issues?q=is%3Aissue) and nobody has asked for this broker yet
+          required: true
+        - label: I read the [roadmap](https://github.com/amigoer/mq-studio/blob/main/docs/ROADMAP.md)
+          required: true
+
+  - type: dropdown
+    id: broker
+    attributes:
+      label: Which broker
+      options:
+        - ActiveMQ
+        - NSQ
+        - Amazon SQS
+        - Google Pub/Sub
+        - Azure Service Bus
+        - Amazon Kinesis
+        - IBM MQ
+        - Solace
+        - Something else
+    validations:
+      required: true
+
+  - type: input
+    id: other
+    attributes:
+      label: If you chose "Something else", name it
+      placeholder: Apache Artemis
+
+  - type: input
+    id: deployment
+    attributes:
+      label: Version and how you run it
+      placeholder: ActiveMQ Artemis 2.33, three-node cluster on Kubernetes
+    validations:
+      required: true
+
+  - type: textarea
+    id: admin-plane
+    attributes:
+      label: What can be reached from a desktop, and how
+      description: >
+        This is the question that decides whether a driver is possible.
+        MQ Studio has no server component: the app on your machine opens the
+        connection itself, so a driver needs an endpoint it can reach that
+        answers administrative questions — list the destinations, read the
+        consumers and their lag, browse a message without consuming it.
+        Name it if you know it (a management HTTP API, JMX, a protocol-level
+        admin command), and say whether it is reachable from where the app
+        runs or only from inside the cluster.
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: needs
+    attributes:
+      label: What you need it to do first
+      description: Pick as many as apply. This is what sets the order the pages are built in.
+      options:
+        - label: Connect, and list the topics or queues
+        - label: Query and browse messages
+        - label: Produce, resend and redeliver
+        - label: Consumer groups, their lag and their offsets
+        - label: Dead letters
+        - label: Cluster health, nodes and metrics
+        - label: Access control, users and quotas
+
+  - type: checkboxes
+    id: help
+    attributes:
+      label: Could you help
+      description: >
+        No obligation — every box left unticked is fine. The middle one is the
+        most valuable: every driver here is gated by live tests, and those need
+        an environment CI can start.
+      options:
+        - label: I can test a build against a real cluster
+        - label: I can contribute a Docker Compose file the test suite could run against
+        - label: I would like to write the driver myself
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Anything else
+      description: What you use today to administer it, and where that falls short.

--- a/.github/ISSUE_TEMPLATE/6-driver-request.zh-CN.yml
+++ b/.github/ISSUE_TEMPLATE/6-driver-request.zh-CN.yml
@@ -1,0 +1,98 @@
+name: "\U0001F50C 驱动支持请求"
+description: 希望支持一个目前连不上的消息队列
+labels: ["type:driver"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        English speakers please use the **Driver request** template instead.
+
+        驱动是一个一个接入的，每接一个都会做到和现有驱动同样的深度，再开始下一个 ——
+        顺序见[开发计划](https://github.com/amigoer/mq-studio/blob/main/docs/ROADMAP.zh-CN.md)。
+        能让一个家族往前排的，是知道确实有人在用它，以及知道应用能对着什么说话。
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: 提交之前
+      options:
+        - label: 我搜索过[已有的 issue](https://github.com/amigoer/mq-studio/issues?q=is%3Aissue)（含已关闭的），还没有人提过这个消息队列
+          required: true
+        - label: 我看过[开发计划](https://github.com/amigoer/mq-studio/blob/main/docs/ROADMAP.zh-CN.md)
+          required: true
+
+  - type: dropdown
+    id: broker
+    attributes:
+      label: 哪个消息队列
+      options:
+        - ActiveMQ
+        - NSQ
+        - Amazon SQS
+        - Google Pub/Sub
+        - Azure Service Bus
+        - Amazon Kinesis
+        - IBM MQ
+        - Solace
+        - 其他
+    validations:
+      required: true
+
+  - type: input
+    id: other
+    attributes:
+      label: 上面选了「其他」的话，请写出名字
+      placeholder: Apache Artemis
+
+  - type: input
+    id: deployment
+    attributes:
+      label: 版本与部署方式
+      placeholder: ActiveMQ Artemis 2.33，Kubernetes 上的三节点集群
+    validations:
+      required: true
+
+  - type: textarea
+    id: admin-plane
+    attributes:
+      label: 桌面端能连到什么，怎么连
+      description: >
+        这一项决定了驱动能不能做。MQ Studio 没有服务端：连接是你机器上的应用自己发起的，
+        所以驱动需要一个它能直接访问、并且能回答管理类问题的入口 —— 列出目的地、
+        读到消费者和堆积、在不消费的前提下浏览消息。知道的话请写清楚是什么
+        （管理用的 HTTP API、JMX、协议自带的管理命令），以及它是应用所在的位置就能访问，
+        还是只有集群内部才能访问。
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: needs
+    attributes:
+      label: 你最先需要它做到什么
+      description: 可以多选。这决定了页面的建设顺序。
+      options:
+        - label: 能连上，能列出主题或队列
+        - label: 查询和浏览消息
+        - label: 发送、重发与重投
+        - label: 消费组、堆积与位点
+        - label: 死信
+        - label: 集群健康、节点与指标
+        - label: 权限、用户与配额
+
+  - type: checkboxes
+    id: help
+    attributes:
+      label: 你能搭把手吗
+      description: >
+        都不勾也完全没关系。中间那条最有价值：这里每个驱动都由真实环境的测试把关，
+        而这需要一套 CI 能启动的环境。
+      options:
+        - label: 我可以拿真实集群帮忙验证构建
+        - label: 我可以提供一份测试套件能跑的 Docker Compose
+        - label: 我想自己来写这个驱动
+
+  - type: textarea
+    id: context
+    attributes:
+      label: 其他补充
+      description: 你现在用什么来管理它，以及哪里不够用。

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,16 @@
+# The picker offers three kinds in two languages. Blank issues are off because
+# every field below exists to save a round trip asking for it.
+blank_issues_enabled: false
+
+contact_links:
+  - name: Install and download help / 安装与下载帮助
+    url: https://mq-studio.amigoer.com/en/
+    about: Download links and the install guide, before opening an issue about either. / 下载地址与安装指南，遇到安装问题请先看这里。
+
+  - name: Which driver comes next / 驱动路线图
+    url: https://github.com/amigoer/mq-studio/blob/main/docs/ROADMAP.md
+    about: The planned order and what each phase covers. / 驱动的推进顺序与每个阶段的范围。
+
+  - name: Chinese community / 中文社区
+    url: https://linux.do
+    about: Usage questions and general discussion, in Chinese. / 使用问题与日常讨论。

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,45 @@
+<!--
+Thanks for the pull request. The guide is CONTRIBUTING.md (中文：CONTRIBUTING.zh-CN.md).
+Title this pull request the way you would write the commit subject:
+  <type>(<scope>): <subject>   e.g. fix(kafka): keep the offset reset within the retention window
+-->
+
+## What
+
+<!-- What this changes, in a sentence or two. -->
+
+## Why
+
+<!--
+The motivation. If an issue asked for it, link it here and put the footer
+`Closes #NN` in the commit body, or `Refs #NN` when the issue stays open.
+-->
+
+## How to verify
+
+<!--
+What a reviewer should do to see it working: the pages to open, the broker to
+point at, the command to run. For a bug fix, say what it did before.
+-->
+
+## Checklist
+
+- [ ] The title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/), and so do the commits
+- [ ] `make check` passes locally
+- [ ] I read what this touches, and did not leave a half-wired page behind
+
+If it applies:
+
+- [ ] A commit closes an issue → its body has `Closes #NN`, **and** both `CHANGELOG.md` and `CHANGELOG.zh-CN.md` name that number under `Unreleased`. The Changelog check fails otherwise, and a number written inside backticks does not count
+- [ ] New user-facing text is in both `frontend/src/i18n/locales/en.json` and `zh.json`
+- [ ] Docs changed in pairs — `README.md` with `README.zh-CN.md`, and so on
+- [ ] A Go service signature changed → `npm run generate:bindings`, with the result committed
+- [ ] A new live test carries `e2e.Require` with a probe **and** a `Family`, and that family has a shard in `.github/workflows/ci.yml`
+- [ ] A driver was added or a family changed name → every family list in CONTRIBUTING.md is updated
+
+<!--
+On the checks: **Check** and **Build** are the ones that gate this pull request.
+**Package** is skipped on pull requests by design. **Workers Builds** fails on
+every pull request branch here and is not caused by your change — previews are
+not enabled on the account, so only the deployment from `main` can go green.
+-->

--- a/.github/labels.json
+++ b/.github/labels.json
@@ -1,0 +1,147 @@
+{
+  "$comment": [
+    "The label set for this repository, kept here so it can be reviewed in a diff",
+    "rather than remembered. `npm run labels:sync` reports what differs; the same",
+    "command with --apply writes it to GitHub.",
+    "",
+    "Three axes and one workflow group. An issue normally carries one type, one",
+    "area, and a driver when the report is family-specific.",
+    "",
+    "`from` is a rename: the label already exists under that name and carries",
+    "issues, so it is renamed in place rather than replaced, which would drop",
+    "every assignment."
+  ],
+
+  "type": [
+    {
+      "name": "type:bug",
+      "from": "bug",
+      "color": "D73A4A",
+      "description": "Behaves differently from what it should"
+    },
+    {
+      "name": "type:feature",
+      "from": "enhancement",
+      "color": "A2EEEF",
+      "description": "A capability the app should have and does not"
+    },
+    {
+      "name": "type:driver",
+      "color": "EC3013",
+      "description": "A broker family MQ Studio does not connect to yet"
+    },
+    {
+      "name": "type:docs",
+      "from": "documentation",
+      "color": "0075CA",
+      "description": "The README, docs/, or the contributor guides"
+    },
+    {
+      "name": "type:question",
+      "from": "question",
+      "color": "D876E3",
+      "description": "A usage question rather than a defect"
+    }
+  ],
+
+  "area": [
+    {
+      "name": "area:connections",
+      "color": "3F3F46",
+      "description": "The connection list, credentials, endpoints, auto-connect"
+    },
+    {
+      "name": "area:topics",
+      "color": "3F3F46",
+      "description": "Topics, queues, exchanges and bindings"
+    },
+    {
+      "name": "area:messages",
+      "color": "3F3F46",
+      "description": "Query, browse, produce, resend, dead letters"
+    },
+    {
+      "name": "area:consumers",
+      "color": "3F3F46",
+      "description": "Groups, clients, subscriptions, lag, offsets"
+    },
+    {
+      "name": "area:cluster",
+      "color": "3F3F46",
+      "description": "Brokers, nodes, runtime metrics, throughput, alerts"
+    },
+    {
+      "name": "area:admin",
+      "color": "3F3F46",
+      "description": "Access control, users, quotas, policies"
+    },
+    {
+      "name": "area:app",
+      "color": "3F3F46",
+      "description": "The window, settings, updates, packaging"
+    },
+    {
+      "name": "area:i18n",
+      "color": "3F3F46",
+      "description": "Translations and the locale files"
+    },
+    {
+      "name": "area:website",
+      "color": "3F3F46",
+      "description": "The marketing site under website/"
+    },
+    {
+      "name": "area:ci",
+      "color": "3F3F46",
+      "description": "Workflows, checks, and the test environments"
+    }
+  ],
+
+  "driver": [
+    { "name": "driver:rocketmq", "color": "BFDADC", "description": "RocketMQ" },
+    { "name": "driver:kafka", "color": "BFDADC", "description": "Kafka" },
+    { "name": "driver:rabbitmq", "color": "BFDADC", "description": "RabbitMQ" },
+    { "name": "driver:pulsar", "color": "BFDADC", "description": "Pulsar" },
+    { "name": "driver:redis-stream", "color": "BFDADC", "description": "Redis Stream" },
+    { "name": "driver:nats", "color": "BFDADC", "description": "NATS" },
+    { "name": "driver:mqtt", "color": "BFDADC", "description": "MQTT" }
+  ],
+
+  "workflow": [
+    {
+      "name": "needs:info",
+      "color": "FBCA04",
+      "description": "Waiting on the reporter for something"
+    },
+    {
+      "name": "needs:repro",
+      "color": "FBCA04",
+      "description": "Cannot be reproduced here yet"
+    },
+    {
+      "name": "blocked:upstream",
+      "color": "B60205",
+      "description": "Waiting on a fix in a library or in the broker itself"
+    },
+    {
+      "name": "good first issue",
+      "color": "7057FF",
+      "description": "A small, self-contained place to start"
+    },
+    {
+      "name": "help wanted",
+      "color": "008672",
+      "description": "Needs a cluster or a pair of hands this project does not have"
+    },
+    {
+      "name": "duplicate",
+      "color": "CFD3D7",
+      "description": "Already tracked somewhere else"
+    },
+    {
+      "name": "wontfix",
+      "color": "FFFFFF",
+      "description": "Understood, and deliberately not being changed"
+    }
+  ]
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,270 @@
+# Contributing to MQ Studio
+
+[简体中文](CONTRIBUTING.zh-CN.md)
+
+MQ Studio is one desktop client for every message queue, and it grows one
+driver at a time. The most useful thing you can send is a report from a broker
+nobody here runs — a version, a topology, a deployment that behaves differently
+from the ones the tests cover. Code is welcome too, and this file is what you
+need to know before writing any.
+
+## Ways to help
+
+- **Report a bug.** The three issue templates each exist in English and
+  Chinese; pick either language.
+- **Ask for a driver.** The [driver request](https://github.com/amigoer/mq-studio/issues/new?template=5-driver-request.yml)
+  template asks one question that decides whether a driver is possible at all:
+  what the app can reach from a desktop, and how.
+- **Test a release candidate** against a cluster this project has no copy of.
+- **Fix the translations.** Every user-facing string lives in
+  `frontend/src/i18n/locales/en.json` and `zh.json`, and the second one is
+  where a clumsy phrasing is most likely to survive unnoticed.
+- **Write code.** Read the rest of this file first.
+
+## Opening an issue
+
+Blank issues are turned off, and the templates are why: nearly every question a
+maintainer would have to ask is a field on the form. Fill in the version and
+the broker even when the bug looks unrelated to either — that pair is what
+decides whether it can be reproduced here at all.
+
+Issues are read in both English and Chinese. Use whichever you write more
+comfortably; the templates come in both.
+
+## Labels
+
+Three axes and a small workflow group. An issue normally carries one `type:`,
+one `area:`, and a `driver:` when the report is family-specific.
+
+- **`type:`** — `bug`, `feature`, `driver`, `docs`, `question`. The issue
+  templates apply this one for you.
+- **`area:`** — which part of the app: `connections`, `topics`, `messages`,
+  `consumers`, `cluster`, `admin`, `app`, `i18n`, `website`, `ci`.
+- **`driver:`** — the broker family, one per shipped driver.
+- **workflow** — `needs:info`, `needs:repro`, `blocked:upstream`, and the
+  familiar `good first issue`, `help wanted`, `duplicate`, `wontfix`.
+
+The set lives in [`.github/labels.json`](.github/labels.json) rather than only
+on GitHub, so it can be reviewed in a diff and rebuilt after someone deletes one
+by hand:
+
+```bash
+npm run labels:sync              # print what differs
+npm run labels:sync -- --apply   # write it
+```
+
+The dry run is the default because a rename and a prune both change what is
+attached to issues people have already filed.
+
+## Getting set up
+
+You need Go (the version `go.mod` pins), Node.js 20.19+ or 22.12+, npm, and the
+[Wails 3 CLI](https://v3.wails.io). Docker is needed only for the live tests.
+
+```bash
+go install github.com/wailsapp/wails/v3/cmd/wails3@latest
+make install
+make dev
+```
+
+`make help` lists every target. [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)
+has the process model and the repository layout.
+
+## Before you push
+
+```bash
+make check
+```
+
+That is the same gate CI runs: version consistency across the tree, the
+changelog references described below, the frontend build and type check,
+`gofmt`, `go vet`, the Go and frontend unit tests, and a check that the
+generated TypeScript bindings are not stale.
+
+If you changed a Go service signature, regenerate the bindings and commit the
+result:
+
+```bash
+npm run generate:bindings
+```
+
+## Live tests
+
+Every driver is gated by tests that run against a real broker rather than a
+mock. Locally they are opt-in, so a plain `go test ./...` stays offline and
+quick even with every container running:
+
+```bash
+npm run e2e:kafka:up && npm run e2e:kafka:seed
+MQ_STUDIO_E2E=1 go test ./internal/driver/kafka/...
+```
+
+Each family has its own `up`, `seed` and `down` scripts — `npm run` with no
+arguments lists them. `npm run test:e2e` runs the whole live suite against
+whatever is up.
+
+In CI the opt-in variable is not consulted at all. The workflow starts every
+environment, so a missing broker is a failure rather than a skip. Two rules
+follow from that, and a new live test needs both:
+
+- it calls `e2e.Require(t, e2e.Env{...})` with a probe **and** a `Family` — an
+  `Env` without a family could not be claimed by any shard, so it would go
+  unrun instead of red;
+- that family has a shard in [`.github/workflows/ci.yml`](.github/workflows/ci.yml).
+
+## Commits
+
+Commit messages follow [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/)
+and are written in English.
+
+```
+<type>(<scope>): <subject>
+
+[body]
+
+[footer]
+```
+
+- `type` is one of `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`,
+  `perf`, `ci`, `revert`.
+- `scope` is optional and lowercase — the driver, the layer, or the area:
+  `kafka`, `update`, `shell`, `e2e`.
+- `subject` is imperative, lowercase, no trailing period, 50 characters or
+  fewer.
+- The body explains *why*, wrapped at 72 columns. Skip it when the subject
+  says everything.
+- A breaking change takes a `!` after the type and a `BREAKING CHANGE:` footer.
+
+Real examples from this repository:
+
+```
+fix(update): repair the update lifecycle end to end
+feat(nats): add the NATS driver
+ci: gate every change on the changelog naming its issues
+```
+
+## Branches
+
+`<type>/<short-description>` in kebab-case, using the same types as the commits:
+
+```
+feat/rocketmq-namespace
+fix/e2e-seed-silent-failure
+ci/changelog-reference-gate
+```
+
+## The changelog rule
+
+A commit that closes an issue carries the footer `Closes #NN` in its **body**.
+Use `Refs #NN` when the issue deliberately stays open. `Fixes` and `Resolves`
+are not recognised — this repository uses one spelling and a second would only
+split it.
+
+Every `Closes #NN` in the commits since the last tag must then be named in the
+`Unreleased` section of **both** changelogs:
+
+- `CHANGELOG.md`
+- `CHANGELOG.zh-CN.md`
+
+The **Changelog** check fails otherwise, and it names the numbers and the
+commits each arrived on, so the section can be written straight from the
+failure. Run it yourself with `npm run check:refs`.
+
+Two things catch people out:
+
+- A number inside backticks does not count. Code spans are matched first, on
+  purpose: a bullet writing `` `#61` `` as a literal documents nothing.
+- Both files, not either. A reference in English only is reported as a
+  mismatch.
+
+The rule exists because a reader only ever meets a change in the release notes,
+and the commit footer is otherwise the only record of which issue asked for it.
+
+## Things that come in pairs
+
+Anything a user reads exists twice, and the second copy is the one that gets
+forgotten:
+
+| English | Chinese |
+| --- | --- |
+| `README.md` | `README.zh-CN.md` |
+| `CHANGELOG.md` | `CHANGELOG.zh-CN.md` |
+| `CONTRIBUTING.md` | `CONTRIBUTING.zh-CN.md` |
+| `docs/INSTALL.md` | `docs/INSTALL.zh-CN.md` |
+| `docs/ROADMAP.md` | `docs/ROADMAP.zh-CN.md` |
+| `frontend/src/i18n/locales/en.json` | `frontend/src/i18n/locales/zh.json` |
+| `website/src/i18n/en.ts` | `website/src/i18n/zh.ts` |
+| `docs/images/hero-{light,dark}.svg` | `docs/images/hero-{light,dark}.zh-CN.svg` |
+
+## Adding a driver
+
+A driver is a package under `internal/driver/` that satisfies the port in
+`internal/driver/driver.go` and declares its capabilities. The pages draw
+themselves from those declarations, so a capability a driver claims and cannot
+answer produces a page that looks broken rather than honest.
+
+The part that is easy to get wrong is everything *outside* the driver package.
+Two branches that each add a driver never conflict in a table — both rows
+survive the merge — while the prose, the art and the counts beside them are
+single lines only one side touched, and the merge keeps one version silently.
+After adding a family, update all of these:
+
+- `internal/model/mqkind.go` — the kind and its display name.
+- `README.md` and `README.zh-CN.md` — the hero `alt` text, the sentence listing
+  the drivers available today, the driver support table, and the roadmap table.
+- `docs/ROADMAP.md` and `docs/ROADMAP.zh-CN.md`.
+- `docs/images/hero-{light,dark}{,.zh-CN}.svg` — the `<desc>`, the driver count
+  badge, and one drawn lane per family. Four files, and the art needs
+  re-spacing rather than a text edit.
+- `website/src/i18n/en.ts` and `zh.ts` — `meta.description`, `banner.text`,
+  `hero.subtitle`, `drivers.supported`, `drivers.planned` and `roadmap.stages`.
+  `planned` is the dangerous one: left alone it keeps asserting that a shipped
+  driver is unbuilt.
+- `frontend/src/i18n/locales/en.json` and `zh.json` —
+  `page.settings.about.blurb` names the families.
+- `frontend/src/App.tsx` and `frontend/src/mq/navigation.ts` — comments that
+  count families.
+- `.github/ISSUE_TEMPLATE/` — the broker dropdown in the bug and feature forms,
+  in both languages, and the family's removal from the driver request form.
+- `.github/labels.json` — a `driver:<family>` entry, then `npm run labels:sync`.
+- `tests/e2e/<family>/compose.yaml`, the `e2e:<family>:*` scripts in
+  `package.json`, and the shard in `.github/workflows/ci.yml`.
+
+Do not count the families by eye. The capability declarations settle which
+drivers answer which page:
+
+```bash
+grep -rn '^\s*model\.Cap<X>,\s*$' internal/driver/*/*.go
+```
+
+## Pull requests
+
+Open it against `main`. The title is the commit subject — same Conventional
+Commits format, since that is what a squash lands as. The template asks for
+what, why, and how to verify; the third is the one reviewers actually need.
+
+Keep a pull request to one thing. A driver, a fix, a refactor — not two of
+them, and not a refactor smuggled in beside a fix.
+
+Four checks report on a pull request:
+
+- **Check** (`ci.yml`) — starts every broker environment and runs the full
+  gate. This one is yours.
+- **Build** (`website.yml`) — the marketing site, which renders this
+  repository's own markdown at build time. A copy edit to a changelog can break
+  it.
+- **Package** — skipped on pull requests by design.
+- **Workers Builds** — fails on every pull request branch and is **not** caused
+  by your change. Preview deployments are not enabled on the account, so only
+  the deployment from `main` can go green. Ignore it.
+
+## Releases
+
+Releases are cut by the maintainer; [RELEASE.md](RELEASE.md) documents the
+process. Contributors do not need to bump a version — leave `package.json`
+alone and put your entry under `Unreleased`.
+
+## License
+
+By contributing you agree that your work is licensed under the
+[Apache License 2.0](LICENSE), the same as the rest of the project.

--- a/CONTRIBUTING.zh-CN.md
+++ b/CONTRIBUTING.zh-CN.md
@@ -1,0 +1,231 @@
+# 参与 MQ Studio
+
+[English](CONTRIBUTING.md)
+
+MQ Studio 想做的是一个客户端连所有消息队列，而它是一个驱动一个驱动长起来的。最有价值的贡献，
+往往是一份来自这里没人跑过的服务端的报告 —— 一个版本、一种拓扑、一套和测试覆盖到的环境行为不同的
+部署。代码同样欢迎，动手之前请先读完这份文档。
+
+## 可以做些什么
+
+- **报告 Bug。** 三种 issue 模板中英文各有一套，用你顺手的那种语言即可。
+- **申请驱动。** [驱动支持请求](https://github.com/amigoer/mq-studio/issues/new?template=6-driver-request.zh-CN.yml)
+  模板里有一个问题决定了这个驱动能不能做：桌面端能连到什么，怎么连。
+- **帮忙验证**：拿这个项目手里没有的集群跑一跑待发布的版本。
+- **修翻译。** 所有面向用户的文案都在 `frontend/src/i18n/locales/en.json` 与 `zh.json`，
+  别扭的措辞最容易在其中一份里一直留着没人发现。
+- **写代码。** 先把下面这些看完。
+
+## 提 issue
+
+空白 issue 是关掉的，原因就是模板本身：维护者要追着问的东西，基本都已经是表单上的一个字段了。
+即使问题看起来和版本、消息队列都无关，也请把这两项填上 —— 这一对决定了问题在这边能不能复现出来。
+
+issue 用中文或英文都会读。哪种写着顺手用哪种，模板两种都有。
+
+## 标签
+
+三条轴，外加一小组流程标签。一个 issue 通常带一个 `type:`、一个 `area:`，
+如果问题和具体家族有关再带一个 `driver:`。
+
+- **`type:`** —— `bug`、`feature`、`driver`、`docs`、`question`。这一条由 issue
+  模板自动打上。
+- **`area:`** —— 应用的哪一部分：`connections`、`topics`、`messages`、
+  `consumers`、`cluster`、`admin`、`app`、`i18n`、`website`、`ci`。
+- **`driver:`** —— 消息队列家族，每个已发布的驱动一个。
+- **流程** —— `needs:info`、`needs:repro`、`blocked:upstream`，以及常见的
+  `good first issue`、`help wanted`、`duplicate`、`wontfix`。
+
+整套标签放在 [`.github/labels.json`](.github/labels.json) 里，而不是只存在于
+GitHub 上，这样它能在 diff 里被审阅，也能在有人手动删掉某个之后重建出来：
+
+```bash
+npm run labels:sync              # 只打印差异
+npm run labels:sync -- --apply   # 真正写入
+```
+
+默认是空跑，因为改名和清理都会动到别人已经提交的 issue 上挂着的东西。
+
+## 环境准备
+
+需要 Go（版本以 `go.mod` 为准）、Node.js 20.19+ 或 22.12+、npm，以及
+[Wails 3 CLI](https://v3.wails.io)。Docker 只有跑真实环境测试时才需要。
+
+```bash
+go install github.com/wailsapp/wails/v3/cmd/wails3@latest
+make install
+make dev
+```
+
+`make help` 会列出全部命令。进程模型与仓库结构见
+[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)。
+
+## 推送之前
+
+```bash
+make check
+```
+
+这和 CI 跑的是同一道关：版本号在整棵树里是否一致、下面说的 changelog 引用、前端构建与类型检查、
+`gofmt`、`go vet`、Go 与前端单元测试，以及生成的 TypeScript binding 有没有过期。
+
+如果改了 Go service 的签名，重新生成 binding 并提交结果：
+
+```bash
+npm run generate:bindings
+```
+
+## 真实环境测试
+
+每个驱动都由真实服务端的测试把关，而不是 mock。本地是显式开启的，所以即使容器全开着，
+直接跑 `go test ./...` 也仍然是离线且快的：
+
+```bash
+npm run e2e:kafka:up && npm run e2e:kafka:seed
+MQ_STUDIO_E2E=1 go test ./internal/driver/kafka/...
+```
+
+每个家族都有自己的 `up`、`seed`、`down` 脚本，`npm run` 不带参数就能列出来。
+`npm run test:e2e` 会对着当前起着的环境跑整套真实测试。
+
+在 CI 里，这个开关根本不会被读取：workflow 会把所有环境都起起来，因此少一个服务端是失败，
+而不是跳过。由此有两条规则，新增一个真实环境测试两条都要满足：
+
+- 调用 `e2e.Require(t, e2e.Env{...})`，要带探测，**也要带 `Family`** ——
+  没有 family 的 `Env` 不会被任何分片认领，结果是悄悄不跑，而不是变红；
+- 这个 family 在 [`.github/workflows/ci.yml`](.github/workflows/ci.yml) 里有对应的分片。
+
+## 提交信息
+
+提交信息遵循 [Conventional Commits 1.0.0](https://www.conventionalcommits.org/zh-hans/v1.0.0/)，
+并且用英文书写。
+
+```
+<type>(<scope>): <subject>
+
+[body]
+
+[footer]
+```
+
+- `type` 取 `feat`、`fix`、`docs`、`style`、`refactor`、`test`、`chore`、
+  `perf`、`ci`、`revert` 之一。
+- `scope` 可选，小写 —— 驱动名、层名或区域名：`kafka`、`update`、`shell`、`e2e`。
+- `subject` 用祈使语气，小写开头，结尾不加句号，不超过 50 个字符。
+- body 说明*为什么*，按 72 列折行。subject 已经说清楚的就不用写。
+- 破坏性变更在 type 后加 `!`，并附 `BREAKING CHANGE:` footer。
+
+仓库里的真实例子：
+
+```
+fix(update): repair the update lifecycle end to end
+feat(nats): add the NATS driver
+ci: gate every change on the changelog naming its issues
+```
+
+## 分支命名
+
+`<type>/<短描述>`，kebab-case，type 与提交信息用的是同一套：
+
+```
+feat/rocketmq-namespace
+fix/e2e-seed-silent-failure
+ci/changelog-reference-gate
+```
+
+## changelog 规则
+
+关闭 issue 的提交，要在**提交正文**里带上 `Closes #NN` 这行 footer。如果 issue 有意保持打开，
+用 `Refs #NN`。`Fixes` 和 `Resolves` 不被识别 —— 这个仓库只用一种写法，多一种只会把它劈成两半。
+
+自上一个 tag 以来所有提交里的每一个 `Closes #NN`，都必须出现在**两份** changelog 的
+`Unreleased` 小节里：
+
+- `CHANGELOG.md`
+- `CHANGELOG.zh-CN.md`
+
+否则 **Changelog** 这项检查会失败。它会把编号和各自所在的提交都打出来，照着失败信息就能把这一节
+写出来。本地用 `npm run check:refs` 自己跑。
+
+有两点容易踩：
+
+- 写在反引号里的编号不算数。代码片段是先匹配的，这是故意的：一条把 `` `#61` ``
+  当字面量写出来的条目，什么也没有记录下来。
+- 是两份都要，不是任选其一。只在英文那份里出现会被报成不一致。
+
+这条规则的由来是：读者接触一个变更的地方只有发布说明，而除此之外，能说明这个变更是哪个 issue
+提出来的，就只剩提交的 footer 了。
+
+## 成对存在的东西
+
+凡是用户会读到的内容都有两份，而被忘掉的总是第二份：
+
+| 英文 | 中文 |
+| --- | --- |
+| `README.md` | `README.zh-CN.md` |
+| `CHANGELOG.md` | `CHANGELOG.zh-CN.md` |
+| `CONTRIBUTING.md` | `CONTRIBUTING.zh-CN.md` |
+| `docs/INSTALL.md` | `docs/INSTALL.zh-CN.md` |
+| `docs/ROADMAP.md` | `docs/ROADMAP.zh-CN.md` |
+| `frontend/src/i18n/locales/en.json` | `frontend/src/i18n/locales/zh.json` |
+| `website/src/i18n/en.ts` | `website/src/i18n/zh.ts` |
+| `docs/images/hero-{light,dark}.svg` | `docs/images/hero-{light,dark}.zh-CN.svg` |
+
+## 新增一个驱动
+
+一个驱动就是 `internal/driver/` 下的一个包，它实现 `internal/driver/driver.go` 里的端口
+并声明自己的 capability。页面是根据这些声明自己画出来的，所以一个驱动声明了却答不上来的
+capability，画出来的页面看着不像「诚实」，而像「坏了」。
+
+真正容易出错的是驱动包**之外**的部分。两个各自新增驱动的分支在表格里永远不会冲突 ——
+两行都会保留下来 —— 而表格旁边的叙述、插图和计数是只有一边动过的单行，合并时会悄悄留下其中一版。
+新增一个家族之后，下面这些全都要改：
+
+- `internal/model/mqkind.go` —— 新的 kind 和它的展示名。
+- `README.md` 与 `README.zh-CN.md` —— hero 的 `alt` 文案、「目前可用的驱动」那句话、
+  驱动支持表格，以及开发计划表格。
+- `docs/ROADMAP.md` 与 `docs/ROADMAP.zh-CN.md`。
+- `docs/images/hero-{light,dark}{,.zh-CN}.svg` —— 里面的 `<desc>`、驱动数量徽标，
+  以及每个家族一条的示意泳道。四个文件，而且是要重新排版，不是改几个字。
+- `website/src/i18n/en.ts` 与 `zh.ts` —— `meta.description`、`banner.text`、
+  `hero.subtitle`、`drivers.supported`、`drivers.planned` 与 `roadmap.stages`。
+  `planned` 最危险：不改它就会一直声称一个已经发布的驱动还没做。
+- `frontend/src/i18n/locales/en.json` 与 `zh.json` ——
+  `page.settings.about.blurb` 里点了各个家族的名字。
+- `frontend/src/App.tsx` 与 `frontend/src/mq/navigation.ts` —— 注释里对家族数量的计数。
+- `.github/ISSUE_TEMPLATE/` —— Bug 与功能建议表单里的消息队列下拉项，中英两套都要改，
+  同时把这个家族从驱动支持请求表单里去掉。
+- `.github/labels.json` —— 加一条 `driver:<family>`，然后跑 `npm run labels:sync`。
+- `tests/e2e/<family>/compose.yaml`、`package.json` 里的 `e2e:<family>:*` 脚本，
+  以及 `.github/workflows/ci.yml` 里的分片。
+
+不要靠眼睛数家族。哪些驱动能答哪个页面，由 capability 声明说了算：
+
+```bash
+grep -rn '^\s*model\.Cap<X>,\s*$' internal/driver/*/*.go
+```
+
+## Pull Request
+
+提到 `main` 分支。标题就是提交的 subject —— 同样是 Conventional Commits 格式，因为 squash
+之后落下来的就是它。模板里问的是改了什么、为什么、怎么验证，第三项才是评审真正需要的。
+
+一个 PR 只做一件事。一个驱动、一个修复、一次重构 —— 不要两件一起，也不要在修复里顺手夹带重构。
+
+PR 上会报告四项检查：
+
+- **Check**（`ci.yml`）—— 起全部服务端环境并跑完整道关。这一项是你的。
+- **Build**（`website.yml`）—— 官网。它在构建时会渲染本仓库自己的 markdown，
+  所以改一句 changelog 的措辞就可能把它弄挂。
+- **Package** —— PR 上按设计就是跳过的。
+- **Workers Builds** —— 在任何 PR 分支上都会失败，**和你的改动无关**。
+  这个账号没有开预览部署，只有从 `main` 出去的那次部署才可能变绿。忽略它即可。
+
+## 发布
+
+发布由维护者来做，流程见 [RELEASE.md](RELEASE.md)。贡献者不需要动版本号 ——
+`package.json` 保持原样，条目写在 `Unreleased` 下面就好。
+
+## 许可
+
+提交贡献即表示你同意你的工作以 [Apache License 2.0](LICENSE) 授权，与项目其余部分一致。

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ Use `make check` to run project checks, `make package` to build a distributable,
 
 ## Docs
 
-[Architecture](docs/ARCHITECTURE.md) · [Install](docs/INSTALL.md) · [Changelog](CHANGELOG.md) · [Releasing](RELEASE.md) · [Roadmap](docs/ROADMAP.md)
+[Architecture](docs/ARCHITECTURE.md) · [Install](docs/INSTALL.md) · [Contributing](CONTRIBUTING.md) · [Changelog](CHANGELOG.md) · [Releasing](RELEASE.md) · [Roadmap](docs/ROADMAP.md)
 
 ## Community
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -223,7 +223,7 @@ make dev
 
 ## 文档
 
-[架构说明](docs/ARCHITECTURE.md) · [安装说明](docs/INSTALL.zh-CN.md) · [更新日志](CHANGELOG.zh-CN.md) · [发版流程](RELEASE.md) · [路线图](docs/ROADMAP.zh-CN.md)
+[架构说明](docs/ARCHITECTURE.md) · [安装说明](docs/INSTALL.zh-CN.md) · [参与贡献](CONTRIBUTING.zh-CN.md) · [更新日志](CHANGELOG.zh-CN.md) · [发版流程](RELEASE.md) · [路线图](docs/ROADMAP.zh-CN.md)
 
 ## 交流
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "package": "wails3 task package",
     "check:version": "node scripts/check-version.mjs",
     "check:refs": "node scripts/check-refs.mjs",
+    "labels:sync": "node scripts/sync-labels.mjs",
     "go:fmt:check": "bash -c 'files=$(gofmt -l . ); [ -z \"$files\" ] || { echo \"The following Go files are not gofmt-clean:\"; echo \"$files\"; echo \"Run: gofmt -w .\"; exit 1; }'",
     "go:vet": "go vet ./...",
     "frontend:type-check": "npm --prefix frontend run type-check",

--- a/scripts/sync-labels.mjs
+++ b/scripts/sync-labels.mjs
@@ -1,0 +1,117 @@
+// Reconciles the repository's labels with .github/labels.json.
+//
+// Labels are shared state that nothing else in the tree records: they are
+// edited in a web form, and a set that took thought to arrive at can be
+// undone by one person clicking delete. Keeping them in a file makes the set
+// reviewable in a diff and rebuildable after that.
+//
+// A dry run is the default on purpose. Everything this writes lands on GitHub
+// immediately and some of it -- a rename, a prune -- changes what is attached
+// to issues people have already filed, so the plan is printed and nothing
+// happens until --apply says so.
+//
+// Usage:
+//   node scripts/sync-labels.mjs                  print what differs
+//   node scripts/sync-labels.mjs --apply          create, rename and update
+//   node scripts/sync-labels.mjs --apply --prune  also delete labels not in the file
+//
+// Renames come from the `from` field. `bug` and `enhancement` carry issues
+// already, so they are renamed in place; deleting and recreating them would
+// silently strip every assignment.
+import { readFile } from 'node:fs/promises'
+import { execFileSync } from 'node:child_process'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const apply = process.argv.includes('--apply')
+const prune = process.argv.includes('--prune')
+
+function gh(...args) {
+  return execFileSync('gh', args, { cwd: root, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] })
+}
+
+const file = JSON.parse(await readFile(resolve(root, '.github/labels.json'), 'utf8'))
+const wanted = Object.entries(file)
+  .filter(([group]) => !group.startsWith('$'))
+  .flatMap(([, labels]) => labels)
+
+let current
+try {
+  current = JSON.parse(gh('label', 'list', '--limit', '200', '--json', 'name,color,description'))
+} catch (error) {
+  console.error('could not read the labels from GitHub. Is `gh` installed and authenticated?')
+  console.error(String(error.stderr ?? error.message).trim())
+  process.exit(1)
+}
+
+const byName = new Map(current.map((label) => [label.name, label]))
+// GitHub stores the colour without the hash and lowercased; the file writes it
+// the way a designer would. Compare them in one case so a match is a match.
+const same = (a, b) =>
+  a.color.toLowerCase() === b.color.toLowerCase() && (a.description ?? '') === (b.description ?? '')
+
+const plan = []
+for (const label of wanted) {
+  const existing = byName.get(label.name)
+  const source = label.from ? byName.get(label.from) : undefined
+
+  if (!existing && source) plan.push({ action: 'rename', label, from: label.from })
+  else if (!existing) plan.push({ action: 'create', label })
+  else if (!same(existing, label)) plan.push({ action: 'update', label })
+}
+
+// A label the file does not name is reported whether or not --prune is set: an
+// unexpected one is usually a rename that already happened by hand, and seeing
+// it is the point. `from` names are not extras while their rename is pending.
+const claimed = new Set(wanted.flatMap((label) => [label.name, label.from].filter(Boolean)))
+const extra = current.filter((label) => !claimed.has(label.name))
+
+if (plan.length === 0 && extra.length === 0) {
+  console.log('labels: already in sync')
+  process.exit(0)
+}
+
+const describe = (entry) =>
+  entry.action === 'rename'
+    ? `  rename  ${entry.from} -> ${entry.label.name}`
+    : `  ${entry.action.padEnd(6)}  ${entry.label.name}`
+
+for (const entry of plan) console.log(describe(entry))
+for (const label of extra) {
+  console.log(`  ${prune && apply ? 'delete' : 'extra '}  ${label.name}`)
+}
+
+if (!apply) {
+  console.log(`\n${plan.length} change(s), ${extra.length} not in the file.`)
+  console.log('Nothing was written. Re-run with --apply to write it.')
+  if (extra.length > 0 && !prune) console.log('Add --prune to delete the ones the file does not name.')
+  process.exit(0)
+}
+
+let failed = 0
+const run = (what, ...args) => {
+  try {
+    gh(...args)
+  } catch (error) {
+    failed += 1
+    console.error(`failed: ${what}`)
+    console.error(String(error.stderr ?? error.message).trim())
+  }
+}
+
+for (const { action, label, from } of plan) {
+  const fields = ['--color', label.color, '--description', label.description ?? '']
+  if (action === 'rename') run(`rename ${from}`, 'label', 'edit', from, '--name', label.name, ...fields)
+  else if (action === 'create') run(`create ${label.name}`, 'label', 'create', label.name, ...fields)
+  else run(`update ${label.name}`, 'label', 'edit', label.name, ...fields)
+}
+
+if (prune) {
+  for (const label of extra) {
+    run(`delete ${label.name}`, 'label', 'delete', label.name, '--yes')
+  }
+}
+
+console.log(failed === 0 ? '\nlabels: applied' : `\nlabels: ${failed} operation(s) failed`)
+process.exit(failed === 0 ? 0 : 1)


### PR DESCRIPTION
## What

Issue and pull request templates, a contributor guide, and the repository's
label set as a file.

- `.github/ISSUE_TEMPLATE/` — three kinds (bug, feature, driver) in English and
  Chinese, six forms plus a `config.yml` that turns blank issues off and points
  install questions at the site.
- `.github/PULL_REQUEST_TEMPLATE.md` — what / why / how to verify, and a
  checklist split into what always applies and what only sometimes does.
- `CONTRIBUTING.md` / `CONTRIBUTING.zh-CN.md` — setup, `make check`, the
  live-test gate, commit and branch formats, the changelog rule, and the list of
  every place a broker family is named.
- `.github/labels.json` + `scripts/sync-labels.mjs` — 29 labels on three axes,
  with `npm run labels:sync` to reconcile them.

## Why

Issues arrive as free prose, mostly in Chinese, and the same questions get asked
back every time: which version, which broker, what the endpoint can actually
reach. Nothing recorded the conventions a contributor has to follow either — the
changelog rule in particular is enforced by a workflow and documented nowhere.

The driver request form leads with the question that decides whether a driver is
possible at all: what the app can reach from a desktop. There is no server
component to put in front of a broker that only answers from inside its own
cluster.

Labels were the one piece of triage state nothing in the tree recorded. They
live in a web form and a set that took thought to arrive at is one click from
being undone.

## How

The labels were applied before this branch, so the forms can name them:
`bug` and `enhancement` were renamed in place to `type:bug` and `type:feature`
rather than replaced, which would have dropped eight existing assignments.
`invalid` was removed. All 17 existing issues were backfilled with `area:` and
`driver:`.

`sync-labels.mjs` defaults to a dry run, because a rename and a prune both
change what is attached to issues people have already filed.

## Testing

- Every issue form parses as YAML, with unique field ids and no unknown types
- `npm run check:version` and `npm run check:refs` pass
- Every relative link in the new documents resolves
- `npm run labels:sync` reports `already in sync` against the live repository

No application code changes.