### PR TITLE
chore(ci): report coverage to codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,7 +186,7 @@ jobs:
           MQ_STUDIO_E2E_FAMILIES: none
         run: |
           set -euo pipefail
-          go test -json -count=1 ./... | tee results-unit.json | jq -j 'select(.Action == "output") | .Output'
+          go test -json -count=1 -coverprofile=coverage-unit.out ./... | tee results-unit.json | jq -j 'select(.Action == "output") | .Output'
 
       - name: Upload the unit results
         if: always()
@@ -195,6 +195,19 @@ jobs:
           name: results-unit
           path: results-unit.json
           retention-days: 7
+
+      # Reporting only. fail_ci_if_error stays off on purpose: a Codecov
+      # outage, or a fork's pull request which gets no secrets, must not turn
+      # a run red whose tests all passed.
+      - name: Upload the unit coverage
+        if: always()
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage-unit.out
+          flags: unit
+          disable_search: true
+          fail_ci_if_error: false
 
       - name: Check for generated-binding drift
         run: npm run check:bindings
@@ -323,13 +336,23 @@ jobs:
       # MQ_STUDIO_E2E_FAMILIES is what makes the shard a shard: the families it
       # does not name skip, and the ones it does still fail rather than skip
       # when their environment is absent.
+      #
+      # -coverpkg is scoped rather than ./... because internal/bridge and
+      # internal/tray are the only packages that reach wails, and these jobs
+      # deliberately install no GTK headers - ./... would not compile here.
+      # What the scope buys is the driver line an internal/app test walks
+      # through: without it a driver is credited only by its own package's
+      # tests, and the cross-checks would cover nothing.
       - name: Run the ${{ matrix.family }} suite
         env:
           MQ_STUDIO_E2E: '1'
           MQ_STUDIO_E2E_FAMILIES: ${{ matrix.family }}
         run: |
           set -euo pipefail
-          go test -json -count=1 ${{ matrix.packages }} \
+          go test -json -count=1 \
+            -coverprofile="coverage-${{ matrix.family }}.out" \
+            -coverpkg=./internal/app/...,./internal/driver/... \
+            ${{ matrix.packages }} \
             | tee "results-${{ matrix.family }}.json" \
             | jq -j 'select(.Action == "output") | .Output'
 
@@ -340,6 +363,20 @@ jobs:
           name: results-${{ matrix.family }}
           path: results-${{ matrix.family }}.json
           retention-days: 7
+
+      # One flag per family, so Codecov can say which broker a line was
+      # covered against rather than only that something covered it. Codecov
+      # merges the uploads for a commit, so a line the rocketmq shard misses
+      # and the kafka shard hits lands covered.
+      - name: Upload the ${{ matrix.family }} coverage
+        if: always()
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage-${{ matrix.family }}.out
+          flags: e2e-${{ matrix.family }}
+          disable_search: true
+          fail_ci_if_error: false
 
   # The reason the split above is allowed to exist. Sharding lets a test go
   # unrun without anything turning red; this asserts over every shard's output

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ website/node_modules/
 website/dist/
 website/.astro/
 
+# Go coverage profiles, written by `npm run test:cover` and by CI
+coverage*.out
+
 # Task's local checksum cache
 .task/
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
   <a href="https://mq-studio.amigoer.com/en/"><img src="https://img.shields.io/badge/website-mq--studio.amigoer.com-EC3013?style=flat-square&labelColor=1A1A1E" alt="Website"></a>
   <a href="https://github.com/amigoer/mq-studio/releases/latest"><img src="https://img.shields.io/github/v/release/amigoer/mq-studio?style=flat-square&label=release&labelColor=1A1A1E&color=3F3F46" alt="Latest release"></a>
   <a href="https://github.com/amigoer/mq-studio/releases"><img src="https://img.shields.io/github/downloads/amigoer/mq-studio/total?style=flat-square&label=downloads&labelColor=1A1A1E&color=3F3F46" alt="Total downloads"></a>
+  <a href="https://app.codecov.io/gh/amigoer/mq-studio"><img src="https://img.shields.io/codecov/c/github/amigoer/mq-studio?style=flat-square&label=coverage&labelColor=1A1A1E&color=3F3F46" alt="Coverage"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-3F3F46?style=flat-square&labelColor=1A1A1E" alt="Apache-2.0 license"></a>
 </p>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -9,6 +9,7 @@
   <a href="https://mq-studio.amigoer.com/"><img src="https://img.shields.io/badge/website-mq--studio.amigoer.com-EC3013?style=flat-square&labelColor=1A1A1E" alt="官网"></a>
   <a href="https://github.com/amigoer/mq-studio/releases/latest"><img src="https://img.shields.io/github/v/release/amigoer/mq-studio?style=flat-square&label=release&labelColor=1A1A1E&color=3F3F46" alt="最新版本"></a>
   <a href="https://github.com/amigoer/mq-studio/releases"><img src="https://img.shields.io/github/downloads/amigoer/mq-studio/total?style=flat-square&label=downloads&labelColor=1A1A1E&color=3F3F46" alt="下载量"></a>
+  <a href="https://app.codecov.io/gh/amigoer/mq-studio"><img src="https://img.shields.io/codecov/c/github/amigoer/mq-studio?style=flat-square&label=coverage&labelColor=1A1A1E&color=3F3F46" alt="覆盖率"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-3F3F46?style=flat-square&labelColor=1A1A1E" alt="Apache-2.0 许可证"></a>
 </p>
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,25 @@
+# Coverage is reported here, not enforced. CI already gates on gofmt, vet, the
+# unit suite, eight live broker shards and the inventory check in
+# scripts/ci-coverage.mjs; a percentage threshold on top of that would only add
+# a red check that says nothing about whether the change is correct.
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+
+comment:
+  require_changes: true
+
+# None of these carry Go coverage. The frontend and the website have their own
+# toolchains, and everything under tests/ is compose files and seed scripts.
+ignore:
+  - "frontend/**"
+  - "website/**"
+  - "tests/**"
+  - "scripts/**"
+  - "build/**"
+  - "docs/**"

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "website:build": "npm --prefix website run build",
     "test": "npm run test:go && npm run test:frontend",
     "test:go": "go test ./...",
+    "test:cover": "go test -coverprofile=coverage.out ./... && go tool cover -func=coverage.out | tail -n 1",
     "test:frontend": "npm --prefix frontend test",
     "test:e2e": "MQ_STUDIO_E2E=1 go test -count=1 -run 'TestLive|TestPlainBroker' ./internal/app/... ./internal/driver/rocketmq/... ./internal/driver/rabbitmq/... ./internal/driver/kafka/... ./internal/driver/pulsar/... ./internal/driver/redisstream/... ./internal/driver/mqtt/... ./internal/driver/nats/... ./internal/driver/activemq/...",
     "e2e:up": "docker compose -f tests/e2e/rocketmq/compose.yaml up -d --wait",


### PR DESCRIPTION
## What

The unit job and each of the eight broker shards now write a Go coverage profile and upload it to Codecov under its own flag. Adds `codecov.yml`, an `npm run test:cover` script, a coverage badge in both READMEs, and ignores `coverage*.out`.

## Why

Coverage was the one thing this repository reported nowhere. It is worth having on its own terms: most of what the drivers do is reached only by the live shards, so a unit-only number would say almost nothing about them. It is also the last open item on the awesome-go listing, which asks a listed project for a coverage service link.

## How to verify

Nothing to click. On a run of this branch each shard uploads a profile and the Codecov check reports a `unit` flag plus one `e2e-<family>` flag per shard.

Two things here are load-bearing, and both were checked directly rather than assumed:

**`-coverpkg` is scoped to `./internal/app/...,./internal/driver/...`, not `./...`.** The e2e jobs install no GTK headers on purpose, and `internal/bridge` and `internal/tray` are the only packages that reach wails, so `./...` would fail to compile there. Confirmed with one shard's package list:

```
MQ_STUDIO_E2E_FAMILIES=none go test -count=1 \
  -coverprofile=cov.out \
  -coverpkg=./internal/app/...,./internal/driver/... \
  -run ZzzNoSuchTest \
  ./internal/app/... ./internal/driver/rocketmq/...
```

Compiles, writes a 13078-line profile, and emits no "no packages being tested depend on" warning. `go list -deps ./internal/app/...` reaches every driver package and reaches neither bridge nor tray, which is what makes the scope both safe and worth having: without it a driver would be credited only by its own package's tests, and the app-layer cross-checks would cover nothing.

**`-coverprofile` puts `coverage:` lines into the `go test -json` stream that `scripts/ci-coverage.mjs` reads.** They are package-level events carrying no `Test` field, so the script's `if (!event.Test) continue` drops them before they reach the inventory. Ran the script over a profiled `-json` run to confirm: 5 tests seen, 5 covered, exit 0.

This needs a `CODECOV_TOKEN` repository secret. Without one the upload step warns and moves on: `fail_ci_if_error` is off, so neither a Codecov outage nor a fork's pull request can redden a run whose tests all passed. The status checks are informational for the same reason - CI already gates on the suites and on the shard inventory, and a percentage threshold would add a red check that says nothing about whether a change is correct.

## Checklist

- [x] The title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/), and so do the commits
- [x] `make check` passes locally
- [x] I read what this touches, and did not leave a half-wired page behind

If it applies:

- [x] Docs changed in pairs - `README.md` with `README.zh-CN.md`

No issue is closed, no user-facing text is added, no Go signature changes, no new live test and no driver change, so the rest of the list does not apply.
