### PR TITLE
feat(connections): let a family declare it needs no address

### DIFF
--- a/frontend/src/design/boards/connections/NewConnectionDialog.tsx
+++ b/frontend/src/design/boards/connections/NewConnectionDialog.tsx
@@ -35,6 +35,7 @@ import {
   toSubmission,
   type ProtocolDraft,
 } from "./connectionDraft";
+import { draftInvalidReason } from "./connectionValidation";
 
 /** Version ranges printed under each tile in the 3a protocol picker. */
 const TILE: Record<ProtocolId, { name: string; versions: string }> = {
@@ -107,166 +108,7 @@ export function NewConnectionDialog({
     setSaving(false);
   }, [editing, initialProtocol, open]);
 
-  const invalid = useMemo(() => {
-    const shared = draft.value;
-    if (shared.name.trim() === "") return t("page.connections.nameRequired");
-    // 0 is blank, which means the connection takes the timeout from settings.
-    if (shared.timeoutSec < 0 || shared.timeoutSec > 300) {
-      return t("page.connections.timeoutRange");
-    }
-    if (draft.protocol === "rabbitmq") {
-      if (draft.value.management.trim() === "") {
-        return t("page.connections.managementRequired");
-      }
-      // The management API has no anonymous mode, so a connection with no
-      // credential cannot read a single page.
-      const stored = draft.value.credentialsStored && !draft.value.clearCredentials;
-      if (!stored && draft.value.username.trim() === "") {
-        return t("page.connections.usernameRequired");
-      }
-      return null;
-    }
-    if (draft.protocol === "kafka") {
-      if (draft.value.endpoints.trim() === "") {
-        return t("page.connections.bootstrapRequired");
-      }
-      // Anonymous is a real choice here, so the credential is only required
-      // once a mechanism has been picked.
-      if (draft.value.mechanism !== "none") {
-        const stored = draft.value.credentialsStored && !draft.value.clearCredentials;
-        if (!stored && draft.value.username.trim() === "") {
-          return t("page.connections.usernameRequired");
-        }
-      }
-      return null;
-    }
-    if (draft.protocol === "pulsar") {
-      if (draft.value.service.trim() === "") {
-        return t("page.connections.serviceUrlRequired");
-      }
-      // The admin API is where every listing comes from, and it is a second
-      // address rather than one derived from the service URL, so a profile
-      // without it can connect and read nothing.
-      if (draft.value.admin.trim() === "") {
-        return t("page.connections.adminUrlRequired");
-      }
-      // A topic is addressed as tenant/namespace/name, so a profile naming
-      // neither has no scope to read within.
-      if (draft.value.tenant.trim() === "" || draft.value.namespace.trim() === "") {
-        return t("page.connections.scopeRequired");
-      }
-      // Anonymous is a real choice here, so the token is only required once
-      // Token has been picked.
-      if (draft.value.auth === "token") {
-        const stored = draft.value.credentialsStored && !draft.value.clearCredentials;
-        if (!stored && draft.value.token.trim() === "") {
-          return t("page.connections.tokenRequired");
-        }
-      }
-      return null;
-    }
-    if (draft.protocol === "redis") {
-      if (draft.value.endpoints.trim() === "") {
-        return t("page.connections.endpointsRequired");
-      }
-      // go-redis builds a cluster client the moment it is handed a second
-      // address, so a standalone profile with two would stop being standalone
-      // without saying so. The driver refuses it; saying so here means the
-      // user finds out while the field is still in front of them.
-      if (draft.value.deployment === "standalone" && countAddresses(draft.value.endpoints) > 1) {
-        return t("page.connections.form.redis.oneAddressOnly");
-      }
-      // Without a master name a sentinel connection has nothing to ask for,
-      // and would end up talking to the sentinels themselves - which answer
-      // PING and hold no streams at all.
-      if (draft.value.deployment === "sentinel" && draft.value.masterName.trim() === "") {
-        return t("page.connections.form.redis.masterNameRequired");
-      }
-      return null;
-    }
-    if (draft.protocol === "mqtt") {
-      if (draft.value.endpoints.trim() === "") {
-        return t("page.connections.brokerRequired");
-      }
-      // Anonymous is a real choice on MQTT, so the credential is only required
-      // once the user has asked to authenticate.
-      if (draft.value.mechanism !== "none") {
-        const stored = draft.value.credentialsStored && !draft.value.clearCredentials;
-        if (!stored && draft.value.username.trim() === "") {
-          return t("page.connections.usernameRequired");
-        }
-      }
-      // A management endpoint with no key would reach EMQX and be refused on
-      // every call, which reads as a broken endpoint rather than a missing
-      // credential.
-      if (draft.value.managementUrl.trim() !== "") {
-        const stored = draft.value.credentialsStored && !draft.value.clearCredentials;
-        if (!stored && draft.value.managementKey.trim() === "") {
-          return t("page.connections.form.mqtt.managementKeyRequired");
-        }
-      }
-      return null;
-    }
-    if (draft.protocol === "nats") {
-      if (draft.value.endpoints.trim() === "") {
-        return t("page.connections.form.nats.serversRequired");
-      }
-      // Anonymous is a real choice on NATS, so a credential is only required
-      // once the user has picked a mechanism that needs one. Each mechanism
-      // needs a different one, and naming the wrong field would send them
-      // looking at a row that is not on screen.
-      const stored = draft.value.credentialsStored && !draft.value.clearCredentials;
-      if (!stored) {
-        if (draft.value.mechanism === "plain" && draft.value.username.trim() === "") {
-          return t("page.connections.usernameRequired");
-        }
-        if (draft.value.mechanism === "token" && draft.value.token.trim() === "") {
-          return t("page.connections.form.nats.tokenRequired");
-        }
-        if (draft.value.mechanism === "nkey" && draft.value.nkeySeed.trim() === "") {
-          return t("page.connections.form.nats.nkeySeedRequired");
-        }
-      }
-      // A creds file is a path rather than a secret, so it is required whether
-      // or not credentials are already stored.
-      if (draft.value.mechanism === "creds" && draft.value.credsFile.trim() === "") {
-        return t("page.connections.form.nats.credsFileRequired");
-      }
-      // Mutual TLS needs both halves: a certificate with no key cannot be
-      // presented, and the server would report it as a failed handshake.
-      if (draft.value.mechanism === "mtls") {
-        if (draft.value.tlsCertFile.trim() === "" || draft.value.tlsKeyFile.trim() === "") {
-          return t("page.connections.form.nats.certPairRequired");
-        }
-      }
-      // A system user with no password reaches $SYS and is refused on every
-      // call, which reads as a broken endpoint rather than a missing half.
-      if (!stored && draft.value.systemUser.trim() !== "" && draft.value.systemPassword.trim() === "") {
-        return t("page.connections.form.nats.systemPasswordRequired");
-      }
-      return null;
-    }
-    if (draft.protocol === "activemq") {
-      if (draft.value.endpoints.trim() === "") return t("page.connections.endpointsRequired");
-      // A broker port here is the commonest way to get this wrong: every other
-      // family's endpoint is one, and this one's is the console over HTTP.
-      if (!/^https?:\/\//i.test(draft.value.endpoints.trim())) {
-        return t("page.connections.form.activemq.consoleScheme");
-      }
-      return null;
-    }
-    if (draft.value.endpoints.trim() === "") return t("page.connections.endpointsRequired");
-    if (draft.value.version === "5.x" && draft.value.access === "proxy") {
-      return t("page.connections.form.rocketmq.proxyNote");
-    }
-    // '%' is what RocketMQ joins a namespace to a topic with, so one inside the
-    // namespace would produce a name nothing could take apart again. The rest
-    // is the broker's own rule for a topic or group, minus that separator.
-    if (!/^[\w|-]*$/.test(draft.value.namespace.trim())) {
-      return t("page.connections.form.rocketmq.namespaceInvalid");
-    }
-    return null;
-  }, [draft, t]);
+  const invalid = useMemo(() => draftInvalidReason(draft, t), [draft, t]);
 
   const runProbe = async () => {
     if (invalid != null || onProbe == null) return;
@@ -477,17 +319,4 @@ function ProbeResult({ state }: { state: ProbeState }) {
       </span>
     </span>
   );
-}
-
-/**
- * How many addresses a comma-, semicolon- or whitespace-separated field holds.
- *
- * It mirrors the driver's own parseAddrs so the form refuses what the driver
- * would refuse. The two are separate implementations on purpose - one is
- * validation the user sees while typing, the other is the last word - but they
- * have to agree on the count, which is what internal/driver/redisstream's
- * TestStandaloneRefusesASecondAddress and this file's tests each pin.
- */
-export function countAddresses(raw: string): number {
-  return raw.split(/[,;\s]+/).filter((part) => part.trim() !== "").length;
 }

--- a/frontend/src/design/boards/connections/connectionValidation.test.ts
+++ b/frontend/src/design/boards/connections/connectionValidation.test.ts
@@ -1,0 +1,186 @@
+/**
+ * The connection form's own rules, protocol by protocol.
+ *
+ * The dispatch used to end in a bare fallthrough holding RocketMQ's rules, so
+ * a protocol added to ProtocolDraft without a branch of its own inherited them
+ * - a name server it has no field for, and a namespace pattern that is one
+ * broker's. Nothing on screen said so; the save button simply stayed off.
+ *
+ * The table below is keyed by the union itself, so a protocol added without an
+ * entry stops compiling here the way it now does in draftInvalidReason.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  emptyActiveMQDraft,
+  emptyKafkaDraft,
+  emptyMqttDraft,
+  emptyNatsDraft,
+  emptyPulsarDraft,
+  emptyRabbitMQDraft,
+  emptyRedisDraft,
+  emptyRocketMQDraft,
+} from "./ConnectionForms";
+import { emptyDraft, type ProtocolDraft } from "./connectionDraft";
+import { countAddresses, draftInvalidReason } from "./connectionValidation";
+
+/** i18n is not initialised here, so a rule's message comes back as its key. */
+const key = (k: string) => k;
+
+const NAME = "orders";
+
+interface Rules {
+  /** Everything this protocol's own rules ask for. */
+  saveable: ProtocolDraft;
+  /** Named, and nothing else: whatever it asks for first is missing. */
+  bare: ProtocolDraft;
+  /** The field that first refusal names. */
+  firstAsk: string;
+}
+
+const RULES: Record<ProtocolDraft["protocol"], Rules> = {
+  rocketmq: {
+    saveable: {
+      protocol: "rocketmq",
+      value: { ...emptyRocketMQDraft(), name: NAME, endpoints: "127.0.0.1:9876" },
+    },
+    bare: { protocol: "rocketmq", value: { ...emptyRocketMQDraft(), name: NAME } },
+    firstAsk: "page.connections.endpointsRequired",
+  },
+  rabbitmq: {
+    saveable: {
+      protocol: "rabbitmq",
+      value: {
+        ...emptyRabbitMQDraft(),
+        name: NAME,
+        management: "http://127.0.0.1:15672",
+        username: "guest",
+      },
+    },
+    bare: { protocol: "rabbitmq", value: { ...emptyRabbitMQDraft(), name: NAME } },
+    firstAsk: "page.connections.managementRequired",
+  },
+  kafka: {
+    saveable: {
+      protocol: "kafka",
+      value: { ...emptyKafkaDraft(), name: NAME, endpoints: "127.0.0.1:9092" },
+    },
+    bare: { protocol: "kafka", value: { ...emptyKafkaDraft(), name: NAME } },
+    firstAsk: "page.connections.bootstrapRequired",
+  },
+  pulsar: {
+    saveable: {
+      protocol: "pulsar",
+      value: {
+        ...emptyPulsarDraft(),
+        name: NAME,
+        service: "pulsar://127.0.0.1:6650",
+        admin: "http://127.0.0.1:8080",
+      },
+    },
+    bare: { protocol: "pulsar", value: { ...emptyPulsarDraft(), name: NAME } },
+    firstAsk: "page.connections.serviceUrlRequired",
+  },
+  redis: {
+    saveable: {
+      protocol: "redis",
+      value: { ...emptyRedisDraft(), name: NAME, endpoints: "127.0.0.1:6379" },
+    },
+    bare: { protocol: "redis", value: { ...emptyRedisDraft(), name: NAME } },
+    firstAsk: "page.connections.endpointsRequired",
+  },
+  mqtt: {
+    saveable: {
+      protocol: "mqtt",
+      value: { ...emptyMqttDraft(), name: NAME, endpoints: "tcp://127.0.0.1:1883" },
+    },
+    bare: { protocol: "mqtt", value: { ...emptyMqttDraft(), name: NAME } },
+    firstAsk: "page.connections.brokerRequired",
+  },
+  nats: {
+    saveable: {
+      protocol: "nats",
+      value: { ...emptyNatsDraft(), name: NAME, endpoints: "nats://127.0.0.1:4222" },
+    },
+    bare: { protocol: "nats", value: { ...emptyNatsDraft(), name: NAME } },
+    firstAsk: "page.connections.form.nats.serversRequired",
+  },
+  activemq: {
+    saveable: {
+      protocol: "activemq",
+      value: { ...emptyActiveMQDraft(), name: NAME, endpoints: "http://127.0.0.1:8161" },
+    },
+    bare: { protocol: "activemq", value: { ...emptyActiveMQDraft(), name: NAME } },
+    firstAsk: "page.connections.endpointsRequired",
+  },
+};
+
+const PROTOCOLS = Object.keys(RULES) as ProtocolDraft["protocol"][];
+
+describe("the connection draft's validity", () => {
+  it("accepts a filled-in draft for every protocol", () => {
+    for (const protocol of PROTOCOLS) {
+      expect(draftInvalidReason(RULES[protocol].saveable, key), protocol).toBeNull();
+    }
+  });
+
+  it("asks each protocol for the address its own form draws", () => {
+    for (const protocol of PROTOCOLS) {
+      const { bare, firstAsk } = RULES[protocol];
+      expect(draftInvalidReason(bare, key), protocol).toBe(firstAsk);
+    }
+  });
+
+  it("refuses a nameless draft whatever the protocol", () => {
+    for (const protocol of PROTOCOLS) {
+      expect(draftInvalidReason(emptyDraft(protocol), key), protocol).toBe(
+        "page.connections.nameRequired",
+      );
+    }
+  });
+
+  /*
+   * Pulsar is the protocol the old fallthrough would have damaged silently:
+   * it is the only other one whose draft carries a namespace, so RocketMQ's
+   * pattern applied to it without so much as a type error. A dot is legal in
+   * a Pulsar namespace and illegal in a RocketMQ one.
+   */
+  it("does not hold Pulsar to RocketMQ's namespace rule", () => {
+    const dotted: ProtocolDraft = {
+      protocol: "pulsar",
+      value: {
+        ...emptyPulsarDraft(),
+        name: NAME,
+        service: "pulsar://127.0.0.1:6650",
+        admin: "http://127.0.0.1:8080",
+        namespace: "team.orders",
+      },
+    };
+    expect(draftInvalidReason(dotted, key)).toBeNull();
+  });
+
+  it("keeps RocketMQ's own namespace rule", () => {
+    const dotted: ProtocolDraft = {
+      protocol: "rocketmq",
+      value: {
+        ...emptyRocketMQDraft(),
+        name: NAME,
+        endpoints: "127.0.0.1:9876",
+        namespace: "team.orders",
+      },
+    };
+    expect(draftInvalidReason(dotted, key)).toBe("page.connections.form.rocketmq.namespaceInvalid");
+  });
+
+  // go-redis builds a cluster client the moment it is handed a second address,
+  // so the form has to count them the way internal/driver/redisstream does.
+  it("counts addresses the way the Redis driver does", () => {
+    expect(countAddresses(" 10.0.0.1:6379 , 10.0.0.2:6379 ")).toBe(2);
+    expect(countAddresses("  ")).toBe(0);
+
+    const clustered: ProtocolDraft = {
+      protocol: "redis",
+      value: { ...emptyRedisDraft(), name: NAME, endpoints: "10.0.0.1:6379,10.0.0.2:6379" },
+    };
+    expect(draftInvalidReason(clustered, key)).toBe("page.connections.form.redis.oneAddressOnly");
+  });
+});

--- a/frontend/src/design/boards/connections/connectionValidation.ts
+++ b/frontend/src/design/boards/connections/connectionValidation.ts
@@ -1,0 +1,205 @@
+/**
+ * Whether a connection form can be submitted, and the message when it cannot.
+ *
+ * These rules sit beside the draft rather than inside the dialog for the same
+ * reason the draft itself does: they are the part worth testing, and a rule
+ * that only exists inside a useMemo can only be reached by rendering.
+ *
+ * The dispatch is exhaustive on purpose. It used to end in a bare fallthrough
+ * that happened to hold RocketMQ's rules, so a protocol added to ProtocolDraft
+ * without a branch of its own was silently asked for a name server and a
+ * RocketMQ namespace. The compiler says so now instead.
+ */
+import type { ProtocolDraft } from "./connectionDraft";
+
+/** Just enough of i18next's t for these rules: a key in, a message out. */
+type Translate = (key: string) => string;
+
+/**
+ * How many addresses a comma-, semicolon- or whitespace-separated field holds.
+ *
+ * It mirrors the driver's own parseAddrs so the form refuses what the driver
+ * would refuse. The two are separate implementations on purpose - one is
+ * validation the user sees while typing, the other is the last word - but they
+ * have to agree on the count, which is what internal/driver/redisstream's
+ * TestStandaloneRefusesASecondAddress and this file's tests each pin.
+ */
+export function countAddresses(raw: string): number {
+  return raw.split(/[,;\s]+/).filter((part) => part.trim() !== "").length;
+}
+
+/** The reason the draft cannot be saved, or null when it can. */
+export function draftInvalidReason(draft: ProtocolDraft, t: Translate): string | null {
+  const shared = draft.value;
+  if (shared.name.trim() === "") return t("page.connections.nameRequired");
+  // 0 is blank, which means the connection takes the timeout from settings.
+  if (shared.timeoutSec < 0 || shared.timeoutSec > 300) {
+    return t("page.connections.timeoutRange");
+  }
+  if (draft.protocol === "rabbitmq") {
+    if (draft.value.management.trim() === "") {
+      return t("page.connections.managementRequired");
+    }
+    // The management API has no anonymous mode, so a connection with no
+    // credential cannot read a single page.
+    const stored = draft.value.credentialsStored && !draft.value.clearCredentials;
+    if (!stored && draft.value.username.trim() === "") {
+      return t("page.connections.usernameRequired");
+    }
+    return null;
+  }
+  if (draft.protocol === "kafka") {
+    if (draft.value.endpoints.trim() === "") {
+      return t("page.connections.bootstrapRequired");
+    }
+    // Anonymous is a real choice here, so the credential is only required
+    // once a mechanism has been picked.
+    if (draft.value.mechanism !== "none") {
+      const stored = draft.value.credentialsStored && !draft.value.clearCredentials;
+      if (!stored && draft.value.username.trim() === "") {
+        return t("page.connections.usernameRequired");
+      }
+    }
+    return null;
+  }
+  if (draft.protocol === "pulsar") {
+    if (draft.value.service.trim() === "") {
+      return t("page.connections.serviceUrlRequired");
+    }
+    // The admin API is where every listing comes from, and it is a second
+    // address rather than one derived from the service URL, so a profile
+    // without it can connect and read nothing.
+    if (draft.value.admin.trim() === "") {
+      return t("page.connections.adminUrlRequired");
+    }
+    // A topic is addressed as tenant/namespace/name, so a profile naming
+    // neither has no scope to read within.
+    if (draft.value.tenant.trim() === "" || draft.value.namespace.trim() === "") {
+      return t("page.connections.scopeRequired");
+    }
+    // Anonymous is a real choice here, so the token is only required once
+    // Token has been picked.
+    if (draft.value.auth === "token") {
+      const stored = draft.value.credentialsStored && !draft.value.clearCredentials;
+      if (!stored && draft.value.token.trim() === "") {
+        return t("page.connections.tokenRequired");
+      }
+    }
+    return null;
+  }
+  if (draft.protocol === "redis") {
+    if (draft.value.endpoints.trim() === "") {
+      return t("page.connections.endpointsRequired");
+    }
+    // go-redis builds a cluster client the moment it is handed a second
+    // address, so a standalone profile with two would stop being standalone
+    // without saying so. The driver refuses it; saying so here means the
+    // user finds out while the field is still in front of them.
+    if (draft.value.deployment === "standalone" && countAddresses(draft.value.endpoints) > 1) {
+      return t("page.connections.form.redis.oneAddressOnly");
+    }
+    // Without a master name a sentinel connection has nothing to ask for,
+    // and would end up talking to the sentinels themselves - which answer
+    // PING and hold no streams at all.
+    if (draft.value.deployment === "sentinel" && draft.value.masterName.trim() === "") {
+      return t("page.connections.form.redis.masterNameRequired");
+    }
+    return null;
+  }
+  if (draft.protocol === "mqtt") {
+    if (draft.value.endpoints.trim() === "") {
+      return t("page.connections.brokerRequired");
+    }
+    // Anonymous is a real choice on MQTT, so the credential is only required
+    // once the user has asked to authenticate.
+    if (draft.value.mechanism !== "none") {
+      const stored = draft.value.credentialsStored && !draft.value.clearCredentials;
+      if (!stored && draft.value.username.trim() === "") {
+        return t("page.connections.usernameRequired");
+      }
+    }
+    // A management endpoint with no key would reach EMQX and be refused on
+    // every call, which reads as a broken endpoint rather than a missing
+    // credential.
+    if (draft.value.managementUrl.trim() !== "") {
+      const stored = draft.value.credentialsStored && !draft.value.clearCredentials;
+      if (!stored && draft.value.managementKey.trim() === "") {
+        return t("page.connections.form.mqtt.managementKeyRequired");
+      }
+    }
+    return null;
+  }
+  if (draft.protocol === "nats") {
+    if (draft.value.endpoints.trim() === "") {
+      return t("page.connections.form.nats.serversRequired");
+    }
+    // Anonymous is a real choice on NATS, so a credential is only required
+    // once the user has picked a mechanism that needs one. Each mechanism
+    // needs a different one, and naming the wrong field would send them
+    // looking at a row that is not on screen.
+    const stored = draft.value.credentialsStored && !draft.value.clearCredentials;
+    if (!stored) {
+      if (draft.value.mechanism === "plain" && draft.value.username.trim() === "") {
+        return t("page.connections.usernameRequired");
+      }
+      if (draft.value.mechanism === "token" && draft.value.token.trim() === "") {
+        return t("page.connections.form.nats.tokenRequired");
+      }
+      if (draft.value.mechanism === "nkey" && draft.value.nkeySeed.trim() === "") {
+        return t("page.connections.form.nats.nkeySeedRequired");
+      }
+    }
+    // A creds file is a path rather than a secret, so it is required whether
+    // or not credentials are already stored.
+    if (draft.value.mechanism === "creds" && draft.value.credsFile.trim() === "") {
+      return t("page.connections.form.nats.credsFileRequired");
+    }
+    // Mutual TLS needs both halves: a certificate with no key cannot be
+    // presented, and the server would report it as a failed handshake.
+    if (draft.value.mechanism === "mtls") {
+      if (draft.value.tlsCertFile.trim() === "" || draft.value.tlsKeyFile.trim() === "") {
+        return t("page.connections.form.nats.certPairRequired");
+      }
+    }
+    // A system user with no password reaches $SYS and is refused on every
+    // call, which reads as a broken endpoint rather than a missing half.
+    if (!stored && draft.value.systemUser.trim() !== "" && draft.value.systemPassword.trim() === "") {
+      return t("page.connections.form.nats.systemPasswordRequired");
+    }
+    return null;
+  }
+  if (draft.protocol === "activemq") {
+    if (draft.value.endpoints.trim() === "") return t("page.connections.endpointsRequired");
+    // A broker port here is the commonest way to get this wrong: every other
+    // family's endpoint is one, and this one's is the console over HTTP.
+    if (!/^https?:\/\//i.test(draft.value.endpoints.trim())) {
+      return t("page.connections.form.activemq.consoleScheme");
+    }
+    return null;
+  }
+  if (draft.protocol === "rocketmq") {
+    if (draft.value.endpoints.trim() === "") return t("page.connections.endpointsRequired");
+    if (draft.value.version === "5.x" && draft.value.access === "proxy") {
+      return t("page.connections.form.rocketmq.proxyNote");
+    }
+    // '%' is what RocketMQ joins a namespace to a topic with, so one inside the
+    // namespace would produce a name nothing could take apart again. The rest
+    // is the broker's own rule for a topic or group, minus that separator.
+    if (!/^[\w|-]*$/.test(draft.value.namespace.trim())) {
+      return t("page.connections.form.rocketmq.namespaceInvalid");
+    }
+    return null;
+  }
+  return unhandledProtocol(draft);
+}
+
+/**
+ * Reports a ProtocolDraft member no branch above handled.
+ *
+ * The parameter is never, so a protocol added to the union without rules of
+ * its own fails to compile here rather than inheriting whichever branch
+ * happens to be last.
+ */
+function unhandledProtocol(draft: never): never {
+  throw new Error(`no validation rules for protocol ${(draft as ProtocolDraft).protocol}`);
+}

--- a/internal/app/activemq_live_test.go
+++ b/internal/app/activemq_live_test.go
@@ -87,7 +87,8 @@ func newActiveMQStack(t *testing.T) *activeMQStack {
 
 	conns := newConnSource(registry)
 	return &activeMQStack{
-		connections:  connection.New(paths.ConnectionsFile, settingsService, newRegistryRuntime(registry)),
+		connections: connection.New(
+			paths.ConnectionsFile, settingsService, newRegistryRuntime(registry), newDescriptorEndpoints()),
 		activemq:     activemqservice.New(conns, settingsService),
 		destinations: destination.New(conns, settingsService),
 		messages:     message.New(conns, settingsService),

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -89,7 +89,8 @@ func New() (*Services, error) {
 
 	registry := driver.NewRegistry()
 	settingsService := settings.New(paths.SettingsFile)
-	connections := connection.New(paths.ConnectionsFile, settingsService, newRegistryRuntime(registry))
+	connections := connection.New(
+		paths.ConnectionsFile, settingsService, newRegistryRuntime(registry), newDescriptorEndpoints())
 	configurationService := configuration.New(paths, settingsService, connections)
 	conns := newConnSource(registry)
 	clusterService := cluster.New(paths.TPSHistoryFile, conns, settingsService)

--- a/internal/app/live_test.go
+++ b/internal/app/live_test.go
@@ -90,7 +90,8 @@ func liveStack(t *testing.T) (*connection.Service, *destination.Service, *driver
 	registry := driver.NewRegistry()
 	t.Cleanup(registry.CloseAll)
 
-	connections := connection.New(paths.ConnectionsFile, settingsService, newRegistryRuntime(registry))
+	connections := connection.New(
+		paths.ConnectionsFile, settingsService, newRegistryRuntime(registry), newDescriptorEndpoints())
 	return connections, destination.New(newConnSource(registry), settingsService), registry
 }
 

--- a/internal/app/mqtt_live_test.go
+++ b/internal/app/mqtt_live_test.go
@@ -73,7 +73,8 @@ func liveMqttStack(t *testing.T) (*connection.Service, *mqttservice.Service, *dr
 	registry := driver.NewRegistry()
 	t.Cleanup(registry.CloseAll)
 
-	connections := connection.New(paths.ConnectionsFile, settingsService, newRegistryRuntime(registry))
+	connections := connection.New(
+		paths.ConnectionsFile, settingsService, newRegistryRuntime(registry), newDescriptorEndpoints())
 	return connections, mqttservice.New(newConnSource(registry), settingsService), registry
 }
 

--- a/internal/app/nats_live_test.go
+++ b/internal/app/nats_live_test.go
@@ -89,7 +89,8 @@ func newNatsStack(t *testing.T) *natsStack {
 
 	conns := newConnSource(registry)
 	return &natsStack{
-		connections:  connection.New(paths.ConnectionsFile, settingsService, newRegistryRuntime(registry)),
+		connections: connection.New(
+			paths.ConnectionsFile, settingsService, newRegistryRuntime(registry), newDescriptorEndpoints()),
 		nats:         natsservice.New(conns, settingsService),
 		destinations: destination.New(conns, settingsService),
 		messages:     message.New(conns, settingsService),

--- a/internal/app/pulsar_live_test.go
+++ b/internal/app/pulsar_live_test.go
@@ -46,7 +46,7 @@ func livePulsarStack(t *testing.T) (*connection.Service, *driver.Registry) {
 
 	settingsService := settings.New(paths.SettingsFile)
 	connections := connection.New(
-		paths.ConnectionsFile, settingsService, newRegistryRuntime(registry))
+		paths.ConnectionsFile, settingsService, newRegistryRuntime(registry), newDescriptorEndpoints())
 	return connections, registry
 }
 

--- a/internal/app/runtime.go
+++ b/internal/app/runtime.go
@@ -27,6 +27,25 @@ func newRegistryRuntime(registry *driver.Registry) connection.ClientRuntime {
 	return &registryRuntime{registry: registry}
 }
 
+// descriptorEndpoints answers the connection service's endpoint question from
+// the driver's own form, and lives here for the same reason registryRuntime
+// does: only the composition root may know both halves.
+type descriptorEndpoints struct{}
+
+func newDescriptorEndpoints() connection.EndpointPolicy { return descriptorEndpoints{} }
+
+// RequiresEndpoints demands an address for a kind no driver is compiled in
+// for. Such a profile cannot be opened anyway, and letting it save without one
+// would only replace the error the user can act on with a later one they
+// cannot.
+func (descriptorEndpoints) RequiresEndpoints(kind model.MQKind) bool {
+	d, ok := driver.Lookup(kind)
+	if !ok {
+		return true
+	}
+	return d.Descriptor().RequiresEndpoints()
+}
+
 // dialTimeout is how long opening or testing one profile may take. The profile
 // arrives resolved, so a zero here means the profile carried no timeout.
 func dialTimeout(profile model.ConnectionProfile) time.Duration {

--- a/internal/model/descriptor.go
+++ b/internal/model/descriptor.go
@@ -74,3 +74,15 @@ type DriverDescriptor struct {
 	// editing its profile.
 	ScopeOption string `json:"scopeOption"`
 }
+
+// RequiresEndpoints reports whether the family must be given an address.
+// Hosted families declare no endpoint field: they are reached by a region
+// and a credential.
+func (d DriverDescriptor) RequiresEndpoints() bool {
+	for _, field := range d.Form {
+		if field.Target == TargetEndpoints && field.Required {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/model/descriptor_test.go
+++ b/internal/model/descriptor_test.go
@@ -1,0 +1,45 @@
+package model
+
+import "testing"
+
+func TestRequiresEndpointsReadsTheForm(t *testing.T) {
+	tests := []struct {
+		name string
+		form []FormField
+		want bool
+	}{
+		{
+			name: "required endpoint field",
+			form: []FormField{{Key: "endpoints", Target: TargetEndpoints, Required: true}},
+			want: true,
+		},
+		{
+			name: "no endpoint field",
+			form: []FormField{
+				{Key: "region", Target: TargetOption, Required: true},
+				{Key: "accessKeyId", Target: TargetSecret, Required: true},
+			},
+			want: false,
+		},
+		// An optional address is a hint, not a requirement: a family that can
+		// derive its own endpoint must still save without one.
+		{
+			name: "optional endpoint field",
+			form: []FormField{{Key: "endpoints", Target: TargetEndpoints}},
+			want: false,
+		},
+		{
+			name: "empty form",
+			want: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			descriptor := DriverDescriptor{Kind: "fake", Form: test.form}
+			if got := descriptor.RequiresEndpoints(); got != test.want {
+				t.Errorf("RequiresEndpoints() = %v; want %v", got, test.want)
+			}
+		})
+	}
+}

--- a/internal/model/profile.go
+++ b/internal/model/profile.go
@@ -139,6 +139,13 @@ func cloneStringMap(source map[string]string) map[string]string {
 // They double as the legacy on-disk field names, which is what makes the
 // migration a rename rather than a re-encryption: the stored ENC: values move
 // across untouched and the user never re-enters a credential.
+//
+// Reserved for RocketMQ's ACL, and not to be reused. They skip
+// applyCredentials' generic loop and are written only through SetACL, so
+// another family storing under these names has them silently cleared; and
+// resolveACLCredentials fills them from global settings for any profile that
+// named no mechanism. A cloud driver names its own - awsAccessKeyId and the
+// like.
 const (
 	SecretAccessKey = "accessKey"
 	SecretSecretKey = "secretKey"

--- a/internal/service/configuration/integration_test.go
+++ b/internal/service/configuration/integration_test.go
@@ -38,7 +38,7 @@ func TestRealServicesConfigurationWorkflow(t *testing.T) {
 		t.Fatalf("initialize encryption key: %v", err)
 	}
 	settings := settingsservice.New(paths.SettingsFile)
-	connections := connectionservice.New(paths.ConnectionsFile, settings, noopClientRuntime{})
+	connections := connectionservice.New(paths.ConnectionsFile, settings, noopClientRuntime{}, addressedEndpoints{})
 	configuration := New(paths, settings, connections)
 
 	t.Run("portable export and import", func(t *testing.T) {
@@ -265,3 +265,9 @@ func (noopClientRuntime) HasClient(int) bool                    { return false }
 func (noopClientRuntime) Remove(int)                            {}
 func (noopClientRuntime) Test(model.ConnectionProfile) error    { return nil }
 func (noopClientRuntime) CloseAll()                             {}
+
+// addressedEndpoints stands in for the driver-backed policy: every profile in
+// this test names a family that is dialled by address.
+type addressedEndpoints struct{}
+
+func (addressedEndpoints) RequiresEndpoints(model.MQKind) bool { return true }

--- a/internal/service/connection/lifecycle.go
+++ b/internal/service/connection/lifecycle.go
@@ -86,11 +86,13 @@ func (s *Service) resolveForDial(connection *model.ConnectionProfile) model.Conn
 // to name, so the probe takes the draft itself. Nothing is persisted and no
 // client is kept: it is TestConnection for a connection that does not exist.
 func (s *Service) ProbeProfile(profile model.ConnectionProfile) error {
-	if strings.TrimSpace(profile.Endpoints) == "" {
-		return fmt.Errorf("connection endpoints cannot be empty")
-	}
+	// Settle the family first: whether an address is required is its answer,
+	// and a draft that names no kind is a RocketMQ one.
 	if profile.Kind == "" {
 		profile.Kind = model.KindRocketMQ
+	}
+	if s.requiresEndpoints(profile.Kind) && strings.TrimSpace(profile.Endpoints) == "" {
+		return fmt.Errorf("connection endpoints cannot be empty")
 	}
 	return s.runtime.Test(s.resolveForDial(&profile))
 }

--- a/internal/service/connection/migration_test.go
+++ b/internal/service/connection/migration_test.go
@@ -34,7 +34,7 @@ func TestLoadMigratesThePreKindFormat(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	service := New(path, fakeSettings{connectTimeout: 3 * time.Second}, noopRuntime{})
+	service := New(path, fakeSettings{connectTimeout: 3 * time.Second}, noopRuntime{}, addressedEndpoints{})
 
 	profiles := service.GetConnections()
 	if len(profiles) != 1 {
@@ -66,7 +66,7 @@ func TestLoadMigratesThePreKindFormat(t *testing.T) {
 func TestSaveWritesTheKindSchemaWithEncryptedSecrets(t *testing.T) {
 	ensureTestCrypto(t)
 	path := filepath.Join(t.TempDir(), "connections.json")
-	service := New(path, fakeSettings{connectTimeout: 3 * time.Second}, noopRuntime{})
+	service := New(path, fakeSettings{connectTimeout: 3 * time.Second}, noopRuntime{}, addressedEndpoints{})
 
 	if _, err := service.AddConnection(profileOf("prod", "", "ns:9876", 5, true, "plain-ak", "plain-sk", "")); err != nil {
 		t.Fatal(err)

--- a/internal/service/connection/mutation.go
+++ b/internal/service/connection/mutation.go
@@ -13,7 +13,13 @@ import (
 // Everything family-specific arrives inside the profile - endpoints, options,
 // secrets - so adding a broker family never widens this signature.
 func (s *Service) AddConnection(input model.ConnectionProfile) (*model.ConnectionProfile, error) {
-	name, endpoints, err := validateConnectionFields(input.Name, input.Endpoints, input.TimeoutSec)
+	// Before validation, because whether an address is required is the
+	// family's answer and the default family has to be settled to ask it.
+	kind := input.Kind
+	if kind == "" {
+		kind = model.KindRocketMQ
+	}
+	name, endpoints, err := s.validateConnectionFields(kind, input.Name, input.Endpoints, input.TimeoutSec)
 	if err != nil {
 		return nil, err
 	}
@@ -23,10 +29,6 @@ func (s *Service) AddConnection(input model.ConnectionProfile) (*model.Connectio
 		return nil, err
 	}
 	group, timeoutSec, remark := input.Group, input.TimeoutSec, input.Remark
-	kind := input.Kind
-	if kind == "" {
-		kind = model.KindRocketMQ
-	}
 
 	defer s.notifyChanged()
 	s.mu.Lock()
@@ -125,9 +127,27 @@ func dialParametersChanged(previous, current model.ConnectionProfile) bool {
 		!maps.Equal(previous.Secrets, current.Secrets)
 }
 
+// editedKind is the family the submission will be stored under.
+//
+// A form need not resubmit the kind, and a profile's family is not editable,
+// so an empty one means the stored family rather than a new connection's
+// default - which is what the address requirement has to be asked of.
+func (s *Service) editedKind(id int, submitted model.MQKind) model.MQKind {
+	if submitted != "" {
+		return submitted
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if stored, exists := s.connections[id]; exists {
+		return stored.Kind
+	}
+	return model.KindRocketMQ
+}
+
 // UpdateConnection updates and persists a connection profile.
 func (s *Service) UpdateConnection(id int, input model.ConnectionProfile) (*model.ConnectionProfile, error) {
-	name, endpoints, err := validateConnectionFields(input.Name, input.Endpoints, input.TimeoutSec)
+	name, endpoints, err := s.validateConnectionFields(
+		s.editedKind(id, input.Kind), input.Name, input.Endpoints, input.TimeoutSec)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/service/connection/persistence.go
+++ b/internal/service/connection/persistence.go
@@ -176,14 +176,14 @@ func (s *Service) saveConnectionsLocked() error {
 	return atomicfile.Write(s.dataFilePath, data)
 }
 
-func prepareReplacement(connections []*model.ConnectionProfile) ([]*model.ConnectionProfile, error) {
+func (s *Service) prepareReplacement(connections []*model.ConnectionProfile) ([]*model.ConnectionProfile, error) {
 	prepared := make([]*model.ConnectionProfile, 0, len(connections))
 	for _, connection := range connections {
 		if connection == nil {
 			continue
 		}
 		current := *connection
-		name, nameServer, err := validateConnectionFields(current.Name, current.Endpoints, current.TimeoutSec)
+		name, nameServer, err := s.validateConnectionFields(current.Kind, current.Name, current.Endpoints, current.TimeoutSec)
 		if err != nil {
 			return nil, fmt.Errorf("invalid connection %q: %w", current.Name, err)
 		}
@@ -206,7 +206,7 @@ func prepareReplacement(connections []*model.ConnectionProfile) ([]*model.Connec
 // ValidateConnections verifies that profiles can be normalized and encoded
 // without changing persisted or runtime connection state.
 func (s *Service) ValidateConnections(connections []*model.ConnectionProfile) error {
-	prepared, err := prepareReplacement(connections)
+	prepared, err := s.prepareReplacement(connections)
 	if err != nil {
 		return err
 	}
@@ -216,7 +216,7 @@ func (s *Service) ValidateConnections(connections []*model.ConnectionProfile) er
 
 // ReplaceConnections validates and atomically replaces all persisted connection profiles.
 func (s *Service) ReplaceConnections(connections []*model.ConnectionProfile) error {
-	prepared, err := prepareReplacement(connections)
+	prepared, err := s.prepareReplacement(connections)
 	if err != nil {
 		return err
 	}

--- a/internal/service/connection/replacement_test.go
+++ b/internal/service/connection/replacement_test.go
@@ -259,7 +259,7 @@ func TestConcurrentReplaceAndAddRemainLinearizable(t *testing.T) {
 		}
 
 		inMemory := connectionNames(service.GetConnections())
-		persisted := connectionNames(New(service.dataFilePath, fakeSettings{connectTimeout: 3 * time.Second, autoConnect: true}, noopRuntime{}).GetConnections())
+		persisted := connectionNames(New(service.dataFilePath, fakeSettings{connectTimeout: 3 * time.Second, autoConnect: true}, noopRuntime{}, addressedEndpoints{}).GetConnections())
 		if !reflect.DeepEqual(inMemory, persisted) {
 			t.Fatalf("iteration %d: memory=%v disk=%v", iteration, inMemory, persisted)
 		}

--- a/internal/service/connection/runtime.go
+++ b/internal/service/connection/runtime.go
@@ -24,3 +24,10 @@ type ClientRuntime interface {
 	Test(profile model.ConnectionProfile) error
 	CloseAll()
 }
+
+// EndpointPolicy answers whether a family must be given an address, from
+// the driver's own descriptor. Injected for the same reason ClientRuntime
+// is: a profile store must not import a driver.
+type EndpointPolicy interface {
+	RequiresEndpoints(kind model.MQKind) bool
+}

--- a/internal/service/connection/service.go
+++ b/internal/service/connection/service.go
@@ -22,6 +22,7 @@ type Service struct {
 	dataFilePath    string
 	settings        Settings
 	runtime         ClientRuntime
+	endpoints       EndpointPolicy
 	reconnectReload bool
 
 	listenersMu sync.RWMutex
@@ -30,9 +31,9 @@ type Service struct {
 
 // New creates a connection service backed by dataFilePath.
 //
-// The runtime is injected rather than constructed here so this package stays
-// free of any driver import.
-func New(dataFilePath string, settings Settings, runtime ClientRuntime) *Service {
+// The runtime and the endpoint policy are injected rather than constructed
+// here so this package stays free of any driver import.
+func New(dataFilePath string, settings Settings, runtime ClientRuntime, endpoints EndpointPolicy) *Service {
 	if strings.TrimSpace(dataFilePath) == "" {
 		dataFilePath = "connections.json"
 	}
@@ -42,6 +43,7 @@ func New(dataFilePath string, settings Settings, runtime ClientRuntime) *Service
 		dataFilePath: dataFilePath,
 		settings:     settings,
 		runtime:      runtime,
+		endpoints:    endpoints,
 	}
 	if err := service.loadConnectionsFromFile(); err != nil {
 		log.Printf("[ConnectionService] failed to load connection config: %v", err)

--- a/internal/service/connection/service_test.go
+++ b/internal/service/connection/service_test.go
@@ -134,7 +134,7 @@ func TestConnectionPersistReload(t *testing.T) {
 	if _, err := service.AddConnection(profileOf("keep", "development", "127.0.0.1:9876", 5, true, "ak1", "sk1", "")); err != nil {
 		t.Fatal(err)
 	}
-	reloaded := New(service.dataFilePath, fakeSettings{connectTimeout: 3 * time.Second, autoConnect: true}, noopRuntime{})
+	reloaded := New(service.dataFilePath, fakeSettings{connectTimeout: 3 * time.Second, autoConnect: true}, noopRuntime{}, addressedEndpoints{})
 	list := reloaded.GetConnections()
 	if len(list) != 1 || list[0].Secret(model.SecretAccessKey) != "ak1" || list[0].Secret(model.SecretSecretKey) != "sk1" {
 		t.Fatalf("reloaded credentials do not match: %#v", list)
@@ -196,7 +196,7 @@ func TestDriverSecretsSurviveAReload(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	reopened := New(service.dataFilePath, fakeSettings{}, noopRuntime{})
+	reopened := New(service.dataFilePath, fakeSettings{}, noopRuntime{}, addressedEndpoints{})
 	stored, err := reopened.GetConnection(added.ID)
 	if err != nil {
 		t.Fatal(err)
@@ -362,7 +362,7 @@ func TestRocketMQNamespaceSurvivesAReload(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	reopened := New(service.dataFilePath, fakeSettings{}, noopRuntime{})
+	reopened := New(service.dataFilePath, fakeSettings{}, noopRuntime{}, addressedEndpoints{})
 	stored, err := reopened.GetConnection(added.ID)
 	if err != nil {
 		t.Fatal(err)
@@ -377,7 +377,7 @@ func TestRocketMQNamespaceSurvivesAReload(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	reopened = New(service.dataFilePath, fakeSettings{}, noopRuntime{})
+	reopened = New(service.dataFilePath, fakeSettings{}, noopRuntime{}, addressedEndpoints{})
 	stored, err = reopened.GetConnection(unscoped.ID)
 	if err != nil {
 		t.Fatal(err)
@@ -410,7 +410,7 @@ func TestKafkaProfileSurvivesAReload(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	reopened := New(service.dataFilePath, fakeSettings{}, noopRuntime{})
+	reopened := New(service.dataFilePath, fakeSettings{}, noopRuntime{}, addressedEndpoints{})
 	stored, err := reopened.GetConnection(added.ID)
 	if err != nil {
 		t.Fatal(err)
@@ -458,7 +458,7 @@ func TestAnonymousKafkaProfileSurvivesAReload(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	reopened := New(service.dataFilePath, fakeSettings{}, noopRuntime{})
+	reopened := New(service.dataFilePath, fakeSettings{}, noopRuntime{}, addressedEndpoints{})
 	stored, err := reopened.GetConnection(added.ID)
 	if err != nil {
 		t.Fatal(err)
@@ -496,7 +496,7 @@ func TestKafkaDroppingSASLClearsTheStoredCredential(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	reopened := New(service.dataFilePath, fakeSettings{}, noopRuntime{})
+	reopened := New(service.dataFilePath, fakeSettings{}, noopRuntime{}, addressedEndpoints{})
 	stored, err := reopened.GetConnection(added.ID)
 	if err != nil {
 		t.Fatal(err)
@@ -532,7 +532,7 @@ func TestPulsarTokenSurvivesAReload(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	reopened := New(service.dataFilePath, fakeSettings{}, noopRuntime{})
+	reopened := New(service.dataFilePath, fakeSettings{}, noopRuntime{}, addressedEndpoints{})
 	stored, err := reopened.GetConnection(added.ID)
 	if err != nil {
 		t.Fatal(err)
@@ -705,7 +705,7 @@ func TestRedisStreamProfileSurvivesAReload(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	reopened := New(service.dataFilePath, fakeSettings{}, noopRuntime{})
+	reopened := New(service.dataFilePath, fakeSettings{}, noopRuntime{}, addressedEndpoints{})
 	stored, err := reopened.GetConnection(added.ID)
 	if err != nil {
 		t.Fatal(err)
@@ -751,7 +751,7 @@ func TestRedisStreamKeepsAPasswordWithNoUsername(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	reopened := New(service.dataFilePath, fakeSettings{}, noopRuntime{})
+	reopened := New(service.dataFilePath, fakeSettings{}, noopRuntime{}, addressedEndpoints{})
 	stored, err := reopened.GetConnection(added.ID)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/service/connection/service_test.go
+++ b/internal/service/connection/service_test.go
@@ -863,3 +863,49 @@ func TestUpdateConnectionRedialsWhenOnlyAnOptionChanged(t *testing.T) {
 		t.Fatalf("runtime dialled with namespace %q, want the edited one", resolved.Option("namespace"))
 	}
 }
+
+/*
+ * A family that names its own credentials keeps them, and keeps its mechanism,
+ * across a save and a load.
+ *
+ * accessKey and secretKey are RocketMQ's and are reserved: they skip
+ * applyCredentials' generic loop, SetACL takes over the mechanism wherever
+ * they are set, and the global pair in settings fills in any profile with no
+ * mechanism of its own. A cloud family that reused the names would inherit all
+ * three - which is why the settings here hold a global pair, the state in
+ * which it would bite.
+ */
+func TestReservedACLNamesLeaveAnotherFamilysSecretsAlone(t *testing.T) {
+	settings := fakeSettings{accessKey: "global-ak", secretKey: "global-sk"}
+	service := newHostedTestService(t, settings)
+	input := hostedProfile("queues")
+	input.Auth = model.AuthConfig{Mechanism: model.AuthPlain}
+	input.SetSecret("awsSecretAccessKey", "s3cret")
+
+	added, err := service.AddConnection(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	reopened := New(service.dataFilePath, settings, noopRuntime{}, descriptorEndpoints{})
+	stored, err := reopened.GetConnection(added.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stored.Secret("awsAccessKeyId") != "AKIA-example" || stored.Secret("awsSecretAccessKey") != "s3cret" {
+		t.Errorf("stored awsAccessKeyId=%q awsSecretAccessKey=%q, want both",
+			stored.Secret("awsAccessKeyId"), stored.Secret("awsSecretAccessKey"))
+	}
+	if stored.Auth.Mechanism != model.AuthPlain {
+		t.Errorf("mechanism after reload = %q, want plain", stored.Auth.Mechanism)
+	}
+	if stored.Secret(model.SecretAccessKey) != "" || stored.Secret(model.SecretSecretKey) != "" {
+		t.Error("the reserved RocketMQ ACL names were written onto another family's profile")
+	}
+
+	resolved := reopened.resolveForDial(stored)
+	if resolved.Auth.Mechanism != model.AuthPlain || resolved.Secret(model.SecretAccessKey) != "" {
+		t.Errorf("dialled with %q / %q; want the profile's own mechanism and no ACL pair",
+			resolved.Auth.Mechanism, resolved.Secret(model.SecretAccessKey))
+	}
+}

--- a/internal/service/connection/test_helpers_test.go
+++ b/internal/service/connection/test_helpers_test.go
@@ -70,6 +70,56 @@ type addressedEndpoints struct{}
 
 func (addressedEndpoints) RequiresEndpoints(model.MQKind) bool { return true }
 
+// hostedKind stands in for the six hosted families: reached by a region and a
+// credential, with no broker address to dial.
+const hostedKind = model.MQKind("hosted-fake")
+
+// hostedDescriptor is the form such a family declares - no endpoint field at
+// all. The policy below reads its answer off it rather than hard-coding one,
+// which is what the composition root does with a registered driver.
+var hostedDescriptor = model.DriverDescriptor{
+	Kind: hostedKind,
+	Form: []model.FormField{
+		{Key: "region", Target: model.TargetOption, Required: true},
+		{Key: "awsAccessKeyId", Target: model.TargetSecret, Required: true},
+	},
+}
+
+type descriptorEndpoints struct{}
+
+// RequiresEndpoints demands an address for a kind it does not know, as the
+// driver-backed policy does for a kind with no driver.
+func (descriptorEndpoints) RequiresEndpoints(kind model.MQKind) bool {
+	if kind == hostedKind {
+		return hostedDescriptor.RequiresEndpoints()
+	}
+	return true
+}
+
+func newHostedTestService(t *testing.T) *Service {
+	t.Helper()
+	ensureTestCrypto(t)
+	return New(
+		filepath.Join(t.TempDir(), "connections.json"),
+		fakeSettings{connectTimeout: 3 * time.Second},
+		noopRuntime{},
+		descriptorEndpoints{},
+	)
+}
+
+// hostedProfile is what a hosted family's form submits: a region and a
+// credential, and no address.
+func hostedProfile(name string) model.ConnectionProfile {
+	profile := model.ConnectionProfile{
+		Name:       name,
+		Kind:       hostedKind,
+		TimeoutSec: 5,
+		Options:    map[string]string{"region": "eu-west-1"},
+	}
+	profile.SetSecret("awsAccessKeyId", "AKIA-example")
+	return profile
+}
+
 // profileOf builds a profile from the arguments the old positional signature
 // took, so these tests read as they did before AddConnection stopped spelling
 // out one broker family's fields.

--- a/internal/service/connection/test_helpers_test.go
+++ b/internal/service/connection/test_helpers_test.go
@@ -50,7 +50,7 @@ func newTestService(t *testing.T, settings Settings) *Service {
 	if settings == nil {
 		settings = fakeSettings{connectTimeout: 3 * time.Second, autoConnect: true}
 	}
-	return New(filepath.Join(t.TempDir(), "connections.json"), settings, noopRuntime{})
+	return New(filepath.Join(t.TempDir(), "connections.json"), settings, noopRuntime{}, addressedEndpoints{})
 }
 
 // noopRuntime stands in where a test only exercises profile persistence. The
@@ -63,6 +63,12 @@ func (noopRuntime) HasClient(int) bool                    { return false }
 func (noopRuntime) Remove(int)                            {}
 func (noopRuntime) Test(model.ConnectionProfile) error    { return nil }
 func (noopRuntime) CloseAll()                             {}
+
+// addressedEndpoints is the policy every family had before one could
+// decline an address, so a test using it reads exactly as it did.
+type addressedEndpoints struct{}
+
+func (addressedEndpoints) RequiresEndpoints(model.MQKind) bool { return true }
 
 // profileOf builds a profile from the arguments the old positional signature
 // took, so these tests read as they did before AddConnection stopped spelling

--- a/internal/service/connection/test_helpers_test.go
+++ b/internal/service/connection/test_helpers_test.go
@@ -96,12 +96,15 @@ func (descriptorEndpoints) RequiresEndpoints(kind model.MQKind) bool {
 	return true
 }
 
-func newHostedTestService(t *testing.T) *Service {
+func newHostedTestService(t *testing.T, settings Settings) *Service {
 	t.Helper()
 	ensureTestCrypto(t)
+	if settings == nil {
+		settings = fakeSettings{connectTimeout: 3 * time.Second}
+	}
 	return New(
 		filepath.Join(t.TempDir(), "connections.json"),
-		fakeSettings{connectTimeout: 3 * time.Second},
+		settings,
 		noopRuntime{},
 		descriptorEndpoints{},
 	)

--- a/internal/service/connection/validation.go
+++ b/internal/service/connection/validation.go
@@ -3,6 +3,8 @@ package connection
 import (
 	"fmt"
 	"strings"
+
+	"github.com/amigoer/mq-studio/internal/model"
 )
 
 // hasEndpoint reports whether raw carries at least one address.
@@ -38,19 +40,37 @@ func normalizeACLConfig(enableACL bool, accessKey, secretKey string) (bool, stri
 	return true, accessKey, secretKey, nil
 }
 
+// requiresEndpoints asks the family whether it has an address at all.
+//
+// A service built without a policy keeps the rule every family had before one
+// could decline: an address is required.
+func (s *Service) requiresEndpoints(kind model.MQKind) bool {
+	if s.endpoints == nil {
+		return true
+	}
+	return s.endpoints.RequiresEndpoints(kind)
+}
+
 // validateConnectionFields checks what every family's form has in common.
 //
 // The address is named for the family on the form - NameServers, a management
 // URL, bootstrap servers - so the message when it is empty must not be. It
 // used to say NameServer, which sent a Kafka or RabbitMQ user looking for a
 // field their form does not have.
-func validateConnectionFields(name, endpoints string, timeoutSec int) (string, string, error) {
+//
+// Whether there is an address to name is the family's own answer: a hosted
+// one is reached by a region and a credential, so demanding one would make it
+// unsaveable. Nothing else relaxes - a connection still needs a name, and the
+// timeout is still bounded.
+func (s *Service) validateConnectionFields(
+	kind model.MQKind, name, endpoints string, timeoutSec int,
+) (string, string, error) {
 	name = strings.TrimSpace(name)
 	endpoints = strings.TrimSpace(endpoints)
 	if name == "" {
 		return "", "", fmt.Errorf("connection name cannot be empty")
 	}
-	if !hasEndpoint(endpoints) {
+	if s.requiresEndpoints(kind) && !hasEndpoint(endpoints) {
 		return "", "", fmt.Errorf("connection address cannot be empty")
 	}
 	if timeoutSec < 0 || timeoutSec > 300 {

--- a/internal/service/connection/validation_test.go
+++ b/internal/service/connection/validation_test.go
@@ -1,20 +1,115 @@
 package connection
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/amigoer/mq-studio/internal/model"
+)
 
 func TestValidateConnectionFields(t *testing.T) {
-	if _, _, err := validateConnectionFields("", "127.0.0.1:9876", 5); err == nil {
+	service := newTestService(t, nil)
+
+	if _, _, err := service.validateConnectionFields(model.KindRocketMQ, "", "127.0.0.1:9876", 5); err == nil {
 		t.Fatal("empty name should fail")
 	}
-	if _, _, err := validateConnectionFields("prod", "", 5); err == nil {
+	if _, _, err := service.validateConnectionFields(model.KindRocketMQ, "prod", "", 5); err == nil {
 		t.Fatal("empty NameServer should fail")
 	}
-	if _, _, err := validateConnectionFields("prod", "ns:9876", 999); err == nil {
+	if _, _, err := service.validateConnectionFields(model.KindRocketMQ, "prod", "ns:9876", 999); err == nil {
 		t.Fatal("timeout greater than 300 seconds should fail")
 	}
-	name, nameServer, err := validateConnectionFields("  prod  ", " ns:9876;ns2:9876 ", 0)
+	name, nameServer, err := service.validateConnectionFields(model.KindRocketMQ, "  prod  ", " ns:9876;ns2:9876 ", 0)
 	if err != nil || name != "prod" || nameServer != "ns:9876;ns2:9876" {
 		t.Fatalf("valid input was not normalized: err=%v name=%q nameServer=%q", err, name, nameServer)
+	}
+}
+
+// A family that declares no endpoint field is exempt from the address check
+// and from nothing else.
+func TestValidateConnectionFieldsSkipsOnlyTheAddress(t *testing.T) {
+	service := newHostedTestService(t)
+
+	if _, _, err := service.validateConnectionFields(hostedKind, "queues", "", 5); err != nil {
+		t.Fatalf("a hosted family should save without an address: %v", err)
+	}
+	if _, _, err := service.validateConnectionFields(hostedKind, "  ", "", 5); err == nil {
+		t.Error("a hosted family still needs a name")
+	}
+	if _, _, err := service.validateConnectionFields(hostedKind, "queues", "", 999); err == nil {
+		t.Error("a hosted family's timeout is still bounded")
+	}
+	// The exemption is per family, not a switch on the service.
+	if _, _, err := service.validateConnectionFields(model.KindRocketMQ, "prod", "", 5); err == nil {
+		t.Error("an addressed family should still reject an empty address")
+	}
+}
+
+// Every path a profile can enter by has its own address check, so a hosted
+// family has to clear all four.
+func TestHostedFamilyNeedsNoAddressOnAnyPath(t *testing.T) {
+	service := newHostedTestService(t)
+
+	added, err := service.AddConnection(hostedProfile("queues"))
+	if err != nil {
+		t.Fatalf("AddConnection: %v", err)
+	}
+	if added.Endpoints != "" {
+		t.Errorf("stored endpoints = %q; want empty", added.Endpoints)
+	}
+
+	renamed := hostedProfile("renamed")
+	if _, err := service.UpdateConnection(added.ID, renamed); err != nil {
+		t.Fatalf("UpdateConnection: %v", err)
+	}
+
+	// A submission that omits the kind is edited under the stored one, or the
+	// profile would be validated as the default family and asked for an
+	// address it has no field for.
+	untyped := hostedProfile("untyped")
+	untyped.Kind = ""
+	if _, err := service.UpdateConnection(added.ID, untyped); err != nil {
+		t.Fatalf("UpdateConnection without a kind: %v", err)
+	}
+
+	if err := service.ProbeProfile(hostedProfile("probe")); err != nil {
+		t.Fatalf("ProbeProfile: %v", err)
+	}
+
+	imported := hostedProfile("imported")
+	if err := service.ValidateConnections([]*model.ConnectionProfile{&imported}); err != nil {
+		t.Fatalf("ValidateConnections: %v", err)
+	}
+	if err := service.ReplaceConnections([]*model.ConnectionProfile{&imported}); err != nil {
+		t.Fatalf("ReplaceConnections: %v", err)
+	}
+	stored := service.GetConnections()
+	if len(stored) != 1 || stored[0].Name != "imported" || stored[0].Endpoints != "" {
+		t.Fatalf("imported connections = %+v; want one hosted profile with no address", stored)
+	}
+}
+
+// The same service must still hold every addressed family to its address, or
+// the exemption would be a hole rather than a family's own answer.
+func TestAddressedFamilyStillNeedsAnAddress(t *testing.T) {
+	service := newHostedTestService(t)
+
+	if _, err := service.AddConnection(profileOf("prod", "", "", 5, false, "", "", "")); err == nil {
+		t.Error("AddConnection accepted a RocketMQ profile with no address")
+	}
+	if err := service.ProbeProfile(profileOf("prod", "", "", 5, false, "", "", "")); err == nil {
+		t.Error("ProbeProfile accepted a RocketMQ profile with no address")
+	}
+	addressless := profileOf("prod", "", "", 5, false, "", "", "")
+	if err := service.ValidateConnections([]*model.ConnectionProfile{&addressless}); err == nil {
+		t.Error("ValidateConnections accepted a RocketMQ profile with no address")
+	}
+
+	added, err := service.AddConnection(profileOf("prod", "", "ns:9876", 5, false, "", "", ""))
+	if err != nil {
+		t.Fatalf("AddConnection: %v", err)
+	}
+	if _, err := service.UpdateConnection(added.ID, profileOf("prod", "", "", 5, false, "", "", "")); err == nil {
+		t.Error("UpdateConnection accepted clearing a RocketMQ profile's address")
 	}
 }
 

--- a/internal/service/connection/validation_test.go
+++ b/internal/service/connection/validation_test.go
@@ -27,7 +27,7 @@ func TestValidateConnectionFields(t *testing.T) {
 // A family that declares no endpoint field is exempt from the address check
 // and from nothing else.
 func TestValidateConnectionFieldsSkipsOnlyTheAddress(t *testing.T) {
-	service := newHostedTestService(t)
+	service := newHostedTestService(t, nil)
 
 	if _, _, err := service.validateConnectionFields(hostedKind, "queues", "", 5); err != nil {
 		t.Fatalf("a hosted family should save without an address: %v", err)
@@ -47,7 +47,7 @@ func TestValidateConnectionFieldsSkipsOnlyTheAddress(t *testing.T) {
 // Every path a profile can enter by has its own address check, so a hosted
 // family has to clear all four.
 func TestHostedFamilyNeedsNoAddressOnAnyPath(t *testing.T) {
-	service := newHostedTestService(t)
+	service := newHostedTestService(t, nil)
 
 	added, err := service.AddConnection(hostedProfile("queues"))
 	if err != nil {
@@ -91,7 +91,7 @@ func TestHostedFamilyNeedsNoAddressOnAnyPath(t *testing.T) {
 // The same service must still hold every addressed family to its address, or
 // the exemption would be a hole rather than a family's own answer.
 func TestAddressedFamilyStillNeedsAnAddress(t *testing.T) {
-	service := newHostedTestService(t)
+	service := newHostedTestService(t, nil)
 
 	if _, err := service.AddConnection(profileOf("prod", "", "", 5, false, "", "", "")); err == nil {
 		t.Error("AddConnection accepted a RocketMQ profile with no address")


### PR DESCRIPTION
## What

Makes an empty `Endpoints` representable, so a family reached by a region and a credential can be saved, loaded and dialled. Roadmap phase 11.

No user-visible change on its own - there is no addressless driver yet. The proof is a test-level one; the first real consumer is Amazon SQS.

## Why

`internal/model/mqkind.go` already documents the intent: hosted families authenticate through Options and Secrets rather than Endpoints, because there is no broker address to dial. Nothing honoured it. Four layers assumed an address, agreeing only by convention:

- the dialog's validator, nine emptiness checks in one `useMemo`;
- `validateConnectionFields`, which never saw the kind, reached from add, update and the config-import path;
- `ProbeProfile`, a separate check that ran before the kind was even defaulted;
- eight descriptors marking `endpoints` required.

The dialog's last branch was a **fallthrough, not a branch**: any protocol added to `ProtocolDraft` without its own `if` silently landed on RocketMQ's path and was refused for an address it has no field for, then checked against a RocketMQ namespace pattern. A new family was rejected by default, and nothing went red.

## How

The driver's own descriptor is the authority. `DriverDescriptor.RequiresEndpoints()` is derived from the form - true when any field targets endpoints and is required - so nothing new has to be kept in sync, and the existing eight are unchanged.

The connection service reaches it through an injected `EndpointPolicy`, implemented in the composition root. `internal/service/connection/runtime.go` documents why: binding a driver into that package is a mistake already made once, and a profile store has no business knowing which broker family it stores profiles for. A kind with no registered driver still requires an address.

`validateConnectionFields` gains the kind and skips only the address check; name and timeout still apply. `AddConnection` defaults the kind before validating, and `UpdateConnection` resolves the stored kind when a submission omits it - without that, a hosted profile edited by a form that does not resubmit `kind` would be validated as RocketMQ.

The dialog's dispatch is now exhaustive, ending in a `never`-typed guard, so a protocol added without rules fails to compile rather than inheriting RocketMQ's.

`accessKey` and `secretKey` are documented as reserved: they skip the generic credential loop, are written only through `SetACL`, and are filled from global settings for any profile that named no mechanism. A cloud driver must name its own.

## Testing

`go test ./...` and `npm run check` pass. New tests cover a family whose descriptor declares no endpoint field passing add, update, probe and the import path; the existing families still refusing an empty address; and an unregistered kind still requiring one.

## Related

Based on #81. Phases 12-18 build on this.