### PR TITLE
fix(mqtt): close the fake broker once its listener is empty

### DIFF
--- a/internal/driver/mqtt/fake_test.go
+++ b/internal/driver/mqtt/fake_test.go
@@ -110,11 +110,53 @@ func startBroker(t *testing.T, kind string, hook mochi.Hook, config any) (*mochi
 	if err := server.Serve(); err != nil {
 		t.Fatalf("serve: %v", err)
 	}
-	t.Cleanup(func() { _ = server.Close() })
+	t.Cleanup(func() { closeBroker(server, listener.ID()) })
 
 	address := listener.Address()
 	waitForListener(t, address)
 	return server, address
+}
+
+/*
+ * closeBroker shuts a fake broker down once its listener is empty.
+ *
+ * mochi's Clients.GetByListener takes a read lock and then calls Len, which
+ * takes the same lock again. Go's RWMutex does not allow that safely: a writer
+ * arriving between the two - Clients.Delete, which is what a disconnecting
+ * client runs - makes the second read lock wait behind it and it never
+ * returns. Server.Close walks exactly that path, so closing while a client is
+ * still going away hangs the whole package until the binary's own timeout,
+ * naming whichever test happened to be running.
+ *
+ * Waiting for the listener to be empty is what keeps the suite off it: with
+ * nothing left to disconnect, no writer arrives while Close is walking.
+ * mochi-mqtt v2.7.9 is the newest release and none carries a fix.
+ *
+ * The inline client is deliberately not counted. It is the broker's own, it
+ * sits on LocalListener rather than this one, and it never disconnects - so
+ * waiting for the map itself to empty would wait forever.
+ */
+func closeBroker(server *mochi.Server, listenerID string) {
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		if !listenerHasClients(server, listenerID) {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	_ = server.Close()
+}
+
+// listenerHasClients reports whether anything is still attached to one
+// listener. GetAll copies the map under a single read lock, which is the part
+// of this API that is safe to call.
+func listenerHasClients(server *mochi.Server, listenerID string) bool {
+	for _, client := range server.Clients.GetAll() {
+		if client.Net.Listener == listenerID && !client.Closed() {
+			return true
+		}
+	}
+	return false
 }
 
 // freePort finds an address nothing is using, by taking it and giving it back.


### PR DESCRIPTION
## What

Makes the MQTT test fake wait for its listener to have no clients before closing the broker.

## Why

The unit job could fail with `panic: test timed out after 10m0s` and `FAIL internal/driver/mqtt 600s` on a pull request that never touched MQTT. It cost two reruns during the driver work, and it named a different test each time, so it read as a new bug on every appearance.

The cause is in mochi-mqtt:

```go
func (cl *Clients) GetByListener(id string) []*Client {
	cl.RLock()
	defer cl.RUnlock()
	clients := make([]*Client, 0, cl.Len())   // Len takes the same lock again
```

Go's `RWMutex` does not allow a recursive read lock. A writer arriving between the two - `Clients.Delete`, which is what a disconnecting client runs - makes the second `RLock` queue behind it, and it never returns. `Server.Close` walks that path for every listener, so closing while a client was still going away could hang until the test binary's own timeout.

The CI goroutine dump shows exactly that frame, blocked for nine minutes:

```
sync.(*RWMutex).RLock
github.com/mochi-mqtt/server/v2.(*Clients).Len
github.com/mochi-mqtt/server/v2.(*Clients).GetByListener
github.com/mochi-mqtt/server/v2.(*Server).closeListenerClients
...
mq-studio/internal/driver/mqtt.startBroker.func1  (the t.Cleanup)
```

## How

Teardown waits for the listener to drain before calling `Close`. With nothing left to disconnect, no writer arrives while `Close` is walking, so the nested read lock is uncontended.

The broker's own inline client is deliberately not counted - it sits on `LocalListener` rather than the test's, and it never disconnects, so waiting for the client map itself to empty would wait forever. The wait is bounded at ten seconds and `Close` runs either way.

`GetAll` is used rather than `GetByListener` because it copies the map under a single read lock, which is the part of that API that is safe to call.

## Testing

`go test ./...` passes; the MQTT package runs in ~26s across three consecutive runs.

**No reproduction.** The window is a handful of instructions wide, and CI hit it roughly twice in fifteen runs under load. Sixty rounds of a targeted harness - clients disconnecting abruptly while `Close` runs - did not trigger it on the unfixed code, and neither did six concurrent copies of the package. What is established is the mechanism: the source above, and the stack trace showing that exact nesting blocked on the lock. The fix removes the writers that can queue during `Close` rather than relying on timing.

## Related

Upstream v2.7.9 is the newest release and none carries a fix, so this stays until one does.