### PR TITLE
fix(i18n): stop a toast being used as a field label

### DIFF
--- a/frontend/src/design/boards/consumers/ConsumersNats.tsx
+++ b/frontend/src/design/boards/consumers/ConsumersNats.tsx
@@ -383,7 +383,7 @@ export function ConsumersNats() {
                         <Metric value={maxAckPending(panel)} />
                       </span>,
                     ],
-                    [t("board.consumers.nats.created"), mono(createdAt(panel))],
+                    [t("board.consumers.nats.createdAt"), mono(createdAt(panel))],
                   ]}
                 />
 

--- a/frontend/src/design/boards/topics/QueuesSqs.tsx
+++ b/frontend/src/design/boards/topics/QueuesSqs.tsx
@@ -341,7 +341,7 @@ function QueueDetail({
             [t("board.sqs.queues.deadLetterQueue"), entry.deadLetterQueue ?? DASH],
             [t("board.sqs.queues.maxReceiveCount"), count(entry.maxReceiveCount)],
             [t("board.sqs.queues.arn"), entry.arn ?? DASH],
-            [t("board.sqs.queues.created"), formatMessageTime(entry.createdAtMs)],
+            [t("board.sqs.queues.createdAt"), formatMessageTime(entry.createdAtMs)],
             [t("board.sqs.queues.modified"), formatMessageTime(entry.modifiedAtMs)],
           ]}
         />

--- a/frontend/src/design/boards/topics/StreamsKinesis.tsx
+++ b/frontend/src/design/boards/topics/StreamsKinesis.tsx
@@ -275,7 +275,7 @@ function StreamDetail({
             [t("board.kinesis.streams.encryption"), entry.encryption ?? DASH],
             [t("board.kinesis.streams.kmsKey"), entry.kmsKeyId ?? DASH],
             [t("board.kinesis.streams.arn"), entry.arn ?? DASH],
-            [t("board.kinesis.streams.created"), formatMessageTime(entry.createdAtMs)],
+            [t("board.kinesis.streams.createdAt"), formatMessageTime(entry.createdAtMs)],
             [
               t("board.kinesis.streams.shardMetrics"),
               entry.shardMetrics.length === 0

--- a/frontend/src/i18n/keys.test.ts
+++ b/frontend/src/i18n/keys.test.ts
@@ -67,3 +67,44 @@ describe("the two bundles", () => {
     expect(usedKeys().length).toBeGreaterThan(1500);
   });
 });
+
+/**
+ * A key taken with no arguments, whose text wants one.
+ *
+ * `created` is a toast - "Created {{name}}" - and `modified` beside it is a
+ * label. Reusing the toast as the label reads as "Created {{name}}" with the
+ * braces still in it, next to a timestamp: nothing throws, no key is missing,
+ * and the two bundles agree, so every other check here passes. Three boards
+ * had it, one of them since the family shipped.
+ */
+const KEY_WITH_NO_ARGS = /\bt\(\s*"([a-zA-Z][\w.-]*)"\s*\)/g;
+
+function textOf(bundle: unknown, key: string): string | null {
+  let node: unknown = bundle;
+  for (const part of key.split(".")) {
+    if (typeof node !== "object" || node === null || !(part in node)) return null;
+    node = (node as Record<string, unknown>)[part];
+  }
+  return typeof node === "string" ? node : null;
+}
+
+describe.each([
+  ["zh", zh],
+  ["en", en],
+] as const)("the %s bundle", (_language, bundle) => {
+  it("is never asked for an interpolated string without the values", () => {
+    const leaking: string[] = [];
+    for (const [file, source] of Object.entries(sources)) {
+      if (file.includes(".test.")) continue;
+      for (const match of source.matchAll(KEY_WITH_NO_ARGS)) {
+        const key = match[1];
+        if (key == null) continue;
+        const text = textOf(bundle, key);
+        if (text != null && text.includes("{{")) {
+          leaking.push(`${key} -> ${text} (${file})`);
+        }
+      }
+    }
+    expect(leaking).toEqual([]);
+  });
+});

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -3284,6 +3284,7 @@
         "pullHasNoMembers": "A pull consumer has none to count — clients ask when they want messages and hold nothing open in between.",
         "stateOn": "State led by {{server}}.",
         "created": "{{name}} created",
+        "createdAt": "Created",
         "updated": "{{name}} updated",
         "deleted": "{{name}} deleted",
         "deleteFailed": "Could not delete the consumer",
@@ -4797,6 +4798,7 @@
         "throughputLimit": "Throughput limit",
         "arn": "ARN",
         "created": "Created {{name}}",
+        "createdAt": "Created",
         "modified": "Last changed",
         "section": {
           "messages": "Messages",
@@ -5387,6 +5389,7 @@
         "kmsKey": "KMS key",
         "arn": "ARN",
         "created": "Created {{name}}",
+        "createdAt": "Created",
         "shardMetrics": "Shard metrics",
         "shardMetricsNone": "None published",
         "onDemandBadge": "On demand",

--- a/frontend/src/i18n/locales/zh.json
+++ b/frontend/src/i18n/locales/zh.json
@@ -3284,6 +3284,7 @@
         "pullHasNoMembers": "拉模式没有连接数可数——客户端要消息的时候才来问，中间不挂任何东西。",
         "stateOn": "状态由 {{server}} 主导。",
         "created": "{{name}} 已创建",
+        "createdAt": "创建时间",
         "updated": "{{name}} 已更新",
         "deleted": "{{name}} 已删除",
         "deleteFailed": "删除消费者失败",
@@ -4797,6 +4798,7 @@
         "throughputLimit": "吞吐限制",
         "arn": "ARN",
         "created": "已创建 {{name}}",
+        "createdAt": "创建时间",
         "modified": "最后修改",
         "section": {
           "messages": "消息",
@@ -5387,6 +5389,7 @@
         "kmsKey": "KMS 密钥",
         "arn": "ARN",
         "created": "已创建 {{name}}",
+        "createdAt": "创建时间",
         "shardMetrics": "分片指标",
         "shardMetricsNone": "未发布",
         "onDemandBadge": "按需",


### PR DESCRIPTION
## What

Three detail panels rendered a row reading `Created {{name}}` next to a timestamp — braces and all. Found during a manual pass over the new drivers.

## Why

`created` is the toast shown after something is created, so its text carries a `{{name}}`. `modified`, sitting directly beside it in the same panel, is a plain label. Reusing the toast as a label and calling it with no values makes i18next hand back the template.

Nothing caught it, and that is the interesting part: the key exists, both bundles agree on it, the boards render, and the keys resolve — so the coverage test, the parity test and the literal-key test all passed. It is only visible to someone looking at the screen.

NATS has had it since the family shipped; SQS and Kinesis copied the shape.

## How

Each panel takes a `createdAt` label of its own, added beside the toast it was borrowing.

The regression test is the point of the change: any `t("key")` written with **no arguments** must not resolve to text containing `{{`. Mutation-checked — reverting one of the three call sites turns both bundles red, and the other assertions stay green.

## Testing

`npx vitest run` — 143 files, 1599 tests pass.

## Related

Found while walking the UI after #92 completed the roadmap.