### PR TITLE
fix(solace): re-read a queue count the suite is moving

### DIFF
--- a/internal/driver/solace/live_test.go
+++ b/internal/driver/solace/live_test.go
@@ -716,11 +716,33 @@ func TestLiveListScopesReportsEveryMsgVPN(t *testing.T) {
 
 	// The counts come from the same collection counts the listing page uses,
 	// so they are compared against the raw API rather than against a literal.
-	want, err := rawCollectionCount(liveVPN, "queues")
-	if err != nil {
-		t.Fatalf("counting queues over http: %v", err)
+	//
+	// Both sides are read again when they disagree. The rest of this suite
+	// creates and deletes queues in this same Message VPN, so a scope listing
+	// and a raw count taken one after the other can land either side of one of
+	// those - and the figure was never wrong, only sampled twice.
+	got, want := found[liveVPN].Destinations, -1
+	for attempt := 0; attempt < 10; attempt++ {
+		counted, err := rawCollectionCount(liveVPN, "queues")
+		if err != nil {
+			t.Fatalf("counting queues over http: %v", err)
+		}
+		want = counted
+		if got == want {
+			break
+		}
+		time.Sleep(200 * time.Millisecond)
+		refreshed, err := conn.ListScopes(liveContext(t))
+		if err != nil {
+			t.Fatalf("list scopes: %v", err)
+		}
+		for _, scope := range refreshed {
+			if scope.Name == liveVPN {
+				got = scope.Destinations
+			}
+		}
 	}
-	if got := found[liveVPN].Destinations; got != want {
+	if got != want {
 		t.Errorf("%s reports %d queues, want %d", liveVPN, got, want)
 	}
 	if want == 0 {


### PR DESCRIPTION
## What

Makes the Message VPN scope test re-read both sides before reporting a mismatch.

## Why

`TestLiveListScopesReportsEveryMsgVPN` compares the scope listing's queue count against a raw SEMP count. It already avoided a hard-coded literal — but it read the two **one after the other**, and the rest of the suite creates and deletes queues in that same Message VPN.

CI caught it on #93, a change that touches nothing but three frontend strings: `default reports 5 queues, want 4`. The figure was never wrong; it was sampled twice while it was moving.

## How

Both sides are read again when they disagree, with a bounded budget, exactly as the queues cross-check does after the same problem was found there. A count that is genuinely off still fails.

## Testing

Solace live suite run three times against the container — clean each time.

## Related

Same class as the two cross-checks fixed in #92 and the transmission-queue count in #91. Unblocks #93.