### PR TITLE
feat(connections): split the protocol choice from the form

### DIFF
--- a/frontend/src/design/boards/connections/NewConnectionDialog.tsx
+++ b/frontend/src/design/boards/connections/NewConnectionDialog.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Check, RefreshCw, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import {
   Dialog,
   DialogContent,
@@ -14,7 +15,13 @@ import {
   SectionLabel,
 } from "@/components";
 import { ProtocolIcon } from "@/design/icons/ProtocolIcon";
-import { PROTOCOL_ORDER, isProtocolReady, type ProtocolId } from "@/design/data/protocols";
+import {
+  PROTOCOL_GROUPS,
+  PROTOCOL_ORDER,
+  isProtocolReady,
+  protocolsIn,
+  type ProtocolId,
+} from "@/design/data/protocols";
 import { cn, formatErrorMessage } from "@/lib/utils";
 import type { ConnectionDraft, CredentialsMode } from "@/api/connection";
 import type { Connection as ConnectionProfile } from "@/api/models";
@@ -116,6 +123,19 @@ export function NewConnectionDialog({
   const { t } = useTranslation();
   const [draft, setDraft] = useState<ProtocolDraft>(() => emptyDraft("rocketmq"));
   const protocol = draft.protocol;
+  /*
+   * Two steps, not one column.
+   *
+   * The protocol list and the form it configures are separate questions, and
+   * stacking them made the dialog a scroll: fifteen tiles above, the fields
+   * that are actually being filled in below, and every vendor added pushing
+   * the form further down. Each step now has the whole dialog.
+   *
+   * An edit opens on the form and cannot go back - the protocol is what a
+   * stored profile is, so changing it would make this a different connection.
+   */
+  const [step, setStep] = useState<"protocol" | "form">(editing == null ? "protocol" : "form");
+  const [search, setSearch] = useState("");
   const [probe, setProbe] = useState<ProbeState>({ kind: "idle" });
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -132,10 +152,32 @@ export function NewConnectionDialog({
         : "rocketmq";
       setDraft(emptyDraft(wanted));
     }
+    // Open on a new connection so the whole list is browsable, shut on an
+    // edit where the protocol cannot change anyway.
+    setStep(editing == null ? "protocol" : "form");
+    setSearch("");
     setProbe({ kind: "idle" });
     setError(null);
     setSaving(false);
   }, [editing, initialProtocol, open]);
+
+  /*
+   * Matches a protocol against the search box, by the two things the tile
+   * shows: its name and its versions. Typing "managed" finds the hosted
+   * three, and "5.0" finds MQTT - both are on the tile, so both are things
+   * somebody will try.
+   */
+  const matches = useMemo(() => {
+    const needle = search.trim().toLowerCase();
+    return (candidate: ProtocolId) => {
+      if (needle === "") return true;
+      const tile = TILE[candidate];
+      return (
+        tile.name.toLowerCase().includes(needle) ||
+        tile.versions.toLowerCase().includes(needle)
+      );
+    };
+  }, [search]);
 
   const invalid = useMemo(() => draftInvalidReason(draft, t), [draft, t]);
 
@@ -179,47 +221,99 @@ export function NewConnectionDialog({
       <DialogContent className="flex max-h-[85vh] flex-col gap-3.5 overflow-y-auto sm:max-w-[580px]">
         <DialogHeader>
           <DialogTitle>
-            {t(editing != null ? "page.connections.dialogTitleEdit" : "page.connections.dialogTitle")}
+            {t(
+              editing != null
+                ? "page.connections.dialogTitleEdit"
+                : step === "protocol"
+                  ? "page.connections.dialogTitleProtocol"
+                  : "page.connections.dialogTitle",
+            )}
           </DialogTitle>
         </DialogHeader>
-      <div>
-        <SectionLabel style={{ marginBottom: "8px" }}>{t("page.connections.dialogProtocol")}</SectionLabel>
-        <div style={{ display: "grid", gridTemplateColumns: "repeat(6,1fr)", gap: "8px" }}>
-          {PROTOCOL_ORDER.map((p) => {
-            const ready = isProtocolReady(p);
+      {step === "protocol" ? (
+        <>
+          <Input
+            value={search}
+            onChange={(event) => setSearch(event.target.value)}
+            placeholder={t("page.connections.protocolSearch")}
+            autoFocus
+          />
+          {PROTOCOL_GROUPS.map((group) => {
+            const listed = protocolsIn(group.id).filter(matches);
+            if (listed.length === 0) return null;
             return (
-              <button
-                key={p}
-                type="button"
-                aria-pressed={p === protocol}
-                /* Nothing drives the other five yet. And the protocol is what
-                   a stored profile is, so changing it on an edit would make
-                   the dialog a different connection. */
-                disabled={!ready || (editing != null && p !== protocol)}
-                className={cn("ptile", p === protocol && "sel")}
-                onClick={() => {
-                  if (!isDraftable(p)) return;
-                  setDraft(emptyDraft(p));
-                  setProbe({ kind: "idle" });
-                  setError(null);
-                }}
-              >
-                <ProtocolIcon protocol={p} size={18} className="" />
-                {TILE[p].name}
-                <span className="pv">
-                  {ready ? TILE[p].versions : t("page.connections.soon")}
-                </span>
-              </button>
+              <div key={group.id}>
+                <SectionLabel style={{ marginBottom: "8px" }}>{t(group.label)}</SectionLabel>
+                <div style={{ display: "grid", gridTemplateColumns: "repeat(4,1fr)", gap: "8px" }}>
+                  {listed.map((p) => {
+                    const ready = isProtocolReady(p);
+                    return (
+                      <button
+                        key={p}
+                        type="button"
+                        disabled={!ready}
+                        aria-pressed={p === protocol}
+                        /* Highlighted so returning from the form shows which
+                           one is in hand, rather than an unmarked grid. */
+                        className={cn("ptile", p === protocol && "sel")}
+                        onClick={() => {
+                          if (!isDraftable(p)) return;
+                          setDraft(emptyDraft(p));
+                          setProbe({ kind: "idle" });
+                          setError(null);
+                          setStep("form");
+                        }}
+                      >
+                        <ProtocolIcon protocol={p} size={20} className="" />
+                        {TILE[p].name}
+                        <span className="pv">
+                          {ready ? TILE[p].versions : t("page.connections.soon")}
+                        </span>
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
             );
           })}
-        </div>
-        {/* The dimmed tiles say they are off; this says why, once, rather than
-            in a tooltip a disabled button never shows. It names no protocol on
-            purpose: the version that named the ready ones went stale the day
-            Kafka shipped and told people it had no driver. */}
-        <div style={{ marginTop: "8px", fontSize: "11px", color: "var(--c-muted)" }}>
-          {t("page.connections.protocolSoonHint")}
-        </div>
+          {PROTOCOL_ORDER.every((p) => !matches(p)) ? (
+            <div style={{ fontSize: "11px", color: "var(--c-muted)" }}>
+              {t("page.connections.protocolNoMatch")}
+            </div>
+          ) : null}
+          {/* Only when something really is off. The version that printed
+              unconditionally outlived the last dimmed tile and sat there
+              describing protocols that all had drivers. */}
+          {PROTOCOL_ORDER.some((p) => !isProtocolReady(p)) ? (
+            <div style={{ fontSize: "11px", color: "var(--c-muted)" }}>
+              {t("page.connections.protocolSoonHint")}
+            </div>
+          ) : null}
+          <DialogFooter>
+            <Button variant="outline" onClick={onClose}>
+              {t("common.cancel")}
+            </Button>
+          </DialogFooter>
+        </>
+      ) : (
+        <>
+      <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+        {editing == null ? (
+          <Button
+            type="button"
+            size="sm"
+            variant="ghost"
+            onClick={() => {
+              setStep("protocol");
+              setSearch("");
+            }}
+          >
+            {t("page.connections.protocolBack")}
+          </Button>
+        ) : null}
+        <ProtocolIcon protocol={protocol} size={18} className="" />
+        <span style={{ fontWeight: 500 }}>{TILE[protocol].name}</span>
+        <span className="pv">{TILE[protocol].versions}</span>
       </div>
       {draft.protocol === "rabbitmq" ? (
         <RabbitMQForm
@@ -329,6 +423,8 @@ export function NewConnectionDialog({
             {t(editing != null ? "page.connections.dialogSaveOnly" : "page.connections.dialogSave")}
           </Button>
         </DialogFooter>
+        </>
+      )}
       </DialogContent>
     </Dialog>
   );

--- a/frontend/src/design/data/protocolGroups.test.ts
+++ b/frontend/src/design/data/protocolGroups.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import {
+  PROTOCOL_GROUPS,
+  PROTOCOL_ORDER,
+  groupOf,
+  protocolsIn,
+} from "./protocols";
+
+/*
+ * The families the connection dialog's first step lists.
+ *
+ * The dialog itself is not tested here: it mounts through a Radix portal,
+ * which renders nothing without a DOM, so a server-rendered assertion about
+ * its markup passes against an empty string and proves nothing. What is
+ * testable is the data the step is built from, and that is where a protocol
+ * would go missing.
+ *
+ * A Record keyed by ProtocolId already makes a missing family a build error.
+ * These cover what the type cannot: that the picker lists every protocol
+ * exactly once, and that no group is empty and therefore drawn as a heading
+ * with nothing under it.
+ */
+describe("the protocol families", () => {
+  it("list every protocol exactly once between them", () => {
+    const listed = PROTOCOL_GROUPS.flatMap((group) => protocolsIn(group.id));
+    expect([...listed].sort()).toEqual([...PROTOCOL_ORDER].sort());
+    expect(new Set(listed).size).toBe(listed.length);
+  });
+
+  it("keep each protocol in the order the picker uses", () => {
+    for (const group of PROTOCOL_GROUPS) {
+      const members = protocolsIn(group.id);
+      const positions = members.map((p) => PROTOCOL_ORDER.indexOf(p));
+      expect(positions).toEqual([...positions].sort((a, b) => a - b));
+    }
+  });
+
+  it("are none of them empty", () => {
+    for (const group of PROTOCOL_GROUPS) {
+      expect(protocolsIn(group.id).length).toBeGreaterThan(0);
+    }
+  });
+
+  it("agree with groupOf", () => {
+    for (const group of PROTOCOL_GROUPS) {
+      for (const protocol of protocolsIn(group.id)) {
+        expect(groupOf(protocol)).toBe(group.id);
+      }
+    }
+  });
+});

--- a/frontend/src/design/data/protocols.ts
+++ b/frontend/src/design/data/protocols.ts
@@ -694,6 +694,52 @@ const READY: ReadonlySet<ProtocolId> = new Set<ProtocolId>([
   "solace",
 ]);
 
+/**
+ * Which of the three families a protocol belongs to.
+ *
+ * The same split the roadmap and the README already sort drivers into, and the
+ * distinction a reader is actually making: whether they run the broker
+ * themselves, rent it from a cloud, or bought it.
+ *
+ * A Record rather than three arrays, so a protocol added to the union without
+ * a family stops the build here instead of quietly vanishing from the picker.
+ */
+export type ProtocolGroupId = "self-hosted" | "hosted" | "enterprise";
+
+const GROUP_OF: Record<ProtocolId, ProtocolGroupId> = {
+  rocketmq: "self-hosted",
+  kafka: "self-hosted",
+  rabbitmq: "self-hosted",
+  pulsar: "self-hosted",
+  redis: "self-hosted",
+  mqtt: "self-hosted",
+  nats: "self-hosted",
+  activemq: "self-hosted",
+  nsq: "self-hosted",
+  sqs: "hosted",
+  "google-pubsub": "hosted",
+  "azure-servicebus": "hosted",
+  kinesis: "hosted",
+  ibmmq: "enterprise",
+  solace: "enterprise",
+};
+
+/** `label` is a translation key, resolved at render like every other one. */
+export const PROTOCOL_GROUPS: { id: ProtocolGroupId; label: string }[] = [
+  { id: "self-hosted", label: "page.connections.group.selfHosted" },
+  { id: "hosted", label: "page.connections.group.hosted" },
+  { id: "enterprise", label: "page.connections.group.enterprise" },
+];
+
+/** The protocols in one family, in the order the picker lists them. */
+export function protocolsIn(group: ProtocolGroupId): ProtocolId[] {
+  return PROTOCOL_ORDER.filter((protocol) => GROUP_OF[protocol] === group);
+}
+
+export function groupOf(protocol: ProtocolId): ProtocolGroupId {
+  return GROUP_OF[protocol];
+}
+
 export function isProtocolReady(protocol: ProtocolId): boolean {
   return READY.has(protocol);
 }

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1480,7 +1480,16 @@
       "serviceUrlRequired": "A service URL is required",
       "adminUrlRequired": "An admin API address is required",
       "scopeRequired": "A tenant and a namespace are required",
-      "tokenRequired": "A token is required"
+      "tokenRequired": "A token is required",
+      "group": {
+        "selfHosted": "Self-hosted",
+        "hosted": "Cloud-hosted",
+        "enterprise": "Enterprise"
+      },
+      "protocolSearch": "Search protocols",
+      "protocolNoMatch": "No protocol matches that.",
+      "dialogTitleProtocol": "Choose a protocol",
+      "protocolBack": "‹ Back"
     },
     "settings": {
       "title": "Settings",

--- a/frontend/src/i18n/locales/zh.json
+++ b/frontend/src/i18n/locales/zh.json
@@ -1480,7 +1480,16 @@
       "serviceUrlRequired": "请填写服务地址",
       "adminUrlRequired": "请填写管理 API 地址",
       "scopeRequired": "请填写租户和命名空间",
-      "tokenRequired": "请填写 Token"
+      "tokenRequired": "请填写 Token",
+      "group": {
+        "selfHosted": "自托管",
+        "hosted": "云托管",
+        "enterprise": "企业"
+      },
+      "protocolSearch": "搜索协议",
+      "protocolNoMatch": "没有匹配的协议。",
+      "dialogTitleProtocol": "选择协议",
+      "protocolBack": "‹ 返回"
     },
     "settings": {
       "title": "设置",


### PR DESCRIPTION
## What

Makes the new-connection dialog two steps: choose a protocol, then configure it.

## Why

The dialog asked two questions in one column — fifteen protocol tiles, and under them the fields actually being filled in. Every vendor added pushed the form further down, and the tiles were already squeezed to 10.5px across six columns to fit at all, with two names still wrapping and a third row holding three tiles beside three empty cells.

They are separate questions. Grouping the tiles alone would only have tidied the pile; the form still would not have been visible until you scrolled past it.

## How

**Step one** lists the protocols, grouped into the three families the roadmap and README already sort drivers into — self-hosted, cloud-hosted, enterprise — with a search box that filters across all three by name or version (typing `managed` finds the hosted four, `5.0` finds MQTT). Four columns instead of six, so `Google Pub/Sub` and `Azure Service Bus` no longer wrap.

**Step two** is the form and nothing else, headed by the protocol chosen and a way back. Coming back highlights the one in hand.

**An edit opens on step two with no way back.** The protocol is what a stored profile *is*, so changing it would make the dialog a different connection — the old layout expressed that by disabling fourteen tiles the user could still see.

The families come from a `Record<ProtocolId, ProtocolGroupId>`, so a protocol added to the union without one **stops the build** rather than quietly vanishing from the picker. Mutation-checked: removing `solace` fails with `Property 'solace' is missing`.

Also drops the hint that dimmed protocols have no driver yet. It printed unconditionally and has been untrue since the last of the fifteen shipped — the screenshot that prompted this work shows it under a grid with nothing dimmed. It now renders only when one really is unready; the greying mechanism itself is kept for the next family that lands before its driver.

## Testing

`npm run type-check` and the full frontend suite pass — 144 files, 1603 tests.

The new test covers the group data rather than the dialog's markup, and that is deliberate: the dialog mounts through a Radix portal, which renders nothing without a DOM, so a server-rendered assertion about it passes against an empty string and proves nothing. A first attempt at one did exactly that — two assertions "passed" against `''`. What is testable, and where a protocol would actually go missing, is that the families list every protocol exactly once, in picker order, with no empty group.