### PR TITLE
fix(ui): stop the page switch flashing a spinner

### DIFF
--- a/frontend/src/design/boards/BoardState.tsx
+++ b/frontend/src/design/boards/BoardState.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import { useEffect, useRef, useState, type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import { TriangleAlert, Unplug } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -13,6 +13,7 @@ import {
 import { Spinner } from "@/components/ui/spinner";
 import type { BrokerData } from "@/hooks/useBrokerData";
 import { isI18nKey } from "@/lib/utils";
+import { SPINNER_DELAY_MS, SPINNER_MIN_MS } from "./spinnerTiming";
 
 /**
  * The three states every data board reaches before it has rows.
@@ -22,6 +23,43 @@ import { isI18nKey } from "@/lib/utils";
  * genuinely nothing there. Rendering all three as an empty table is how a
  * broken connection reads as an empty cluster.
  */
+/**
+ * Whether a load has run long enough to show a spinner, and not yet long
+ * enough to take it away again.
+ */
+function useSpinnerVisible(loading: boolean): boolean {
+  const [visible, setVisible] = useState(false);
+  const shownAt = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (loading) {
+      const timer = window.setTimeout(() => {
+        shownAt.current = Date.now();
+        setVisible(true);
+      }, SPINNER_DELAY_MS);
+      return () => window.clearTimeout(timer);
+    }
+    if (shownAt.current == null) {
+      setVisible(false);
+      return;
+    }
+    const held = Date.now() - shownAt.current;
+    const left = SPINNER_MIN_MS - held;
+    if (left <= 0) {
+      shownAt.current = null;
+      setVisible(false);
+      return;
+    }
+    const timer = window.setTimeout(() => {
+      shownAt.current = null;
+      setVisible(false);
+    }, left);
+    return () => window.clearTimeout(timer);
+  }, [loading]);
+
+  return visible;
+}
+
 export function BoardState({
   state,
   empty,
@@ -34,6 +72,7 @@ export function BoardState({
   children?: ReactNode;
 }) {
   const { t } = useTranslation();
+  const spinner = useSpinnerVisible(state.loading);
 
   if (!state.online) {
     return (
@@ -42,8 +81,18 @@ export function BoardState({
       </Notice>
     );
   }
-  if (state.loading) {
-    return <Notice icon={<Spinner className="size-5" />} title={t("board.state.loading")} />;
+  if (state.loading || spinner) {
+    /*
+     * Nothing is drawn inside the delay. The column is fading in over roughly
+     * the same span, so a read that lands inside it arrives as content rather
+     * than as a spinner that came and went - and the space is still held, so
+     * nothing below it moves when the rows arrive.
+     */
+    return spinner ? (
+      <Notice icon={<Spinner className="size-5" />} title={t("board.state.loading")} />
+    ) : (
+      <div className="min-h-0 flex-1" aria-busy="true" />
+    );
   }
   if (state.error != null) {
     return (
@@ -66,7 +115,16 @@ export function BoardState({
   return <>{empty ?? children}</>;
 }
 
-/** Whether BoardState will draw over the board instead of its content. */
+/*
+ * Whether BoardState will draw over the board instead of its content.
+ *
+ * It answers from the state alone, so it covers the delay - loading is still
+ * true throughout it - but not the tail after a load finishes while the
+ * spinner is being held. A board that branches on this swaps to its content
+ * there instead of holding; that is what it did before this change, so no
+ * board is worse off, and the ones that pass their content to BoardState get
+ * the hold as well.
+ */
 export function isBlocked(
   state: Pick<BrokerData<unknown>, "loading" | "error" | "online">,
 ): boolean {

--- a/frontend/src/design/boards/kafkaBoards.test.tsx
+++ b/frontend/src/design/boards/kafkaBoards.test.tsx
@@ -201,9 +201,16 @@ describe("the Kafka overview board", () => {
     expect(render(<OverviewKafka />)).toContain("未连接");
   });
 
-  it("draws the loading notice before the first answer", () => {
+  /*
+   * Busy, not yet spinning. A read that lands inside the spinner's delay never
+   * draws one - what has to hold is that the board does not render as though
+   * it had answered.
+   */
+  it("marks itself busy before the first answer", () => {
     clusterState.current = stateOf({ loading: true });
-    expect(render(<OverviewKafka />)).toContain("正在读取");
+    const html = render(<OverviewKafka />);
+    expect(html).toContain('aria-busy="true"');
+    expect(html).not.toContain("正在读取");
   });
 
   it("draws the failure and its reason", () => {
@@ -525,11 +532,17 @@ const transaction = (over: Record<string, unknown> = {}) => ({
  * offset while every other figure reads healthy.
  */
 describe("the Kafka transactions panel", () => {
-  it("says so while it is loading", () => {
+  /*
+   * Busy, not yet spinning. A read that lands inside the spinner's delay never
+   * draws one - what has to hold is that the panel does not render as though
+   * it had answered, which for this one would mean no transactions in flight.
+   */
+  it("marks itself busy while it is loading", () => {
     const html = render(
       <KafkaTransactionsPanel state={stateOf({ loading: true })} now={NOW} />,
     );
-    expect(html).toContain("正在读取");
+    expect(html).toContain('aria-busy="true"');
+    expect(html).not.toContain("正在读取");
   });
 
   it("shows the reason when the cluster would not answer", () => {

--- a/frontend/src/design/boards/redisBoards.test.tsx
+++ b/frontend/src/design/boards/redisBoards.test.tsx
@@ -174,10 +174,17 @@ describe("the Redis streams board", () => {
     expect(html).not.toContain("orders:events");
   });
 
-  it("says it is reading while the first load is in flight", () => {
+  /*
+   * Busy, not yet spinning. A read that lands inside the spinner's delay never
+   * draws one - what has to hold is that the board does not render as though
+   * it had answered.
+   */
+  it("marks itself busy while the first load is in flight", () => {
     streamsState.current = stateOf({ loading: true });
     streamDetailState.current = stateOf({ loading: true });
-    expect(render(<StreamsRedis />)).toContain("正在读取");
+    const html = render(<StreamsRedis />);
+    expect(html).toContain('aria-busy="true"');
+    expect(html).not.toContain("正在读取");
   });
 
   /*
@@ -308,10 +315,17 @@ describe("the Redis consumer groups board", () => {
     expect(html).not.toContain("settle-group");
   });
 
-  it("says it is reading while the first load is in flight", () => {
+  /*
+   * Busy, not yet spinning. A read that lands inside the spinner's delay never
+   * draws one - what has to hold is that the board does not render as though
+   * it had answered.
+   */
+  it("marks itself busy while the first load is in flight", () => {
     groupsState.current = stateOf({ loading: true });
     streamsState.current = stateOf({ loading: true });
-    expect(render(<ConsumersRedis />)).toContain("正在读取");
+    const html = render(<ConsumersRedis />);
+    expect(html).toContain('aria-busy="true"');
+    expect(html).not.toContain("正在读取");
   });
 
   it("shows the driver's reason when the read failed", () => {

--- a/frontend/src/design/boards/spinnerTiming.test.ts
+++ b/frontend/src/design/boards/spinnerTiming.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { SPINNER_DELAY_MS, SPINNER_MIN_MS, spinnerWindow } from "./spinnerTiming";
+
+/*
+ * The policy, in the numbers the app actually sees.
+ *
+ * The figures below were read off the status bar while walking every new
+ * driver against its container, so they are what a page switch costs in
+ * practice rather than a guess. What must hold is that none of them puts a
+ * spinner on screen, and that the one read slow enough to warrant one does
+ * not get it for a moment and then lose it again.
+ */
+describe("the loading spinner", () => {
+  it.each([
+    ["Google Pub/Sub", 18],
+    ["Amazon SQS", 21],
+    ["Amazon Kinesis", 36],
+    ["NSQ", 14],
+    ["Solace", 100],
+  ])("stays away for a %s read (%ims)", (_family, ms) => {
+    expect(spinnerWindow(ms).shown).toBe(false);
+  });
+
+  it("stays away right up to the delay", () => {
+    expect(spinnerWindow(SPINNER_DELAY_MS).shown).toBe(false);
+    expect(spinnerWindow(SPINNER_DELAY_MS + 1).shown).toBe(true);
+  });
+
+  it("never shows for less than the minimum, which is the flicker again", () => {
+    // An IBM MQ queue manager over mqweb: slow enough to say something, fast
+    // enough that a delay on its own would flash.
+    const held = spinnerWindow(386);
+    expect(held.shown).toBe(true);
+    expect(held.forMs).toBeGreaterThanOrEqual(SPINNER_MIN_MS);
+  });
+
+  it("tracks the read once it is past both bounds", () => {
+    expect(spinnerWindow(1200).forMs).toBe(1200 - SPINNER_DELAY_MS);
+  });
+
+  it("is tuned so the minimum outlasts the delay", () => {
+    // A minimum below the delay would let a read just past the delay show a
+    // spinner for less time than it waited to show one.
+    expect(SPINNER_MIN_MS).toBeGreaterThan(SPINNER_DELAY_MS);
+  });
+});

--- a/frontend/src/design/boards/spinnerTiming.ts
+++ b/frontend/src/design/boards/spinnerTiming.ts
@@ -1,0 +1,19 @@
+/*
+ * When a board says it is loading, and for how long it then has to keep
+ * saying it.
+ *
+ * Most reads finish well inside the delay - a queue listing came back in 21ms
+ * against LocalStack, a project's topics in 18ms, a stream listing in 36ms -
+ * and a spinner drawn and taken away inside that reads as a flicker rather
+ * than as loading. The minimum is the other half of the same problem: with a
+ * delay alone, a 386ms read (an IBM MQ queue manager over mqweb) shows the
+ * spinner for 186ms, which is the same flicker moved later.
+ */
+export const SPINNER_DELAY_MS = 200;
+export const SPINNER_MIN_MS = 300;
+
+/** What a load of this length would put on screen. */
+export function spinnerWindow(loadMs: number): { shown: boolean; forMs: number } {
+  if (loadMs <= SPINNER_DELAY_MS) return { shown: false, forMs: 0 };
+  return { shown: true, forMs: Math.max(SPINNER_MIN_MS, loadMs - SPINNER_DELAY_MS) };
+}

--- a/frontend/src/design/tokens.css
+++ b/frontend/src/design/tokens.css
@@ -1323,9 +1323,17 @@ html[data-animations='off'] .mqs-toaster [data-sonner-toast] {
 .mqs-view {
   animation: view-in var(--mo-base) var(--mo-ease-out);
 }
+/*
+ * A little travel, not just a fade. Opacity alone changes the whole column at
+ * once and reads as a flash; 6px of rise gives the eye something to follow, so
+ * the same 180ms reads as the page arriving. The ease-out spends most of that
+ * distance early, which is what keeps it from feeling slow on a page somebody
+ * clicks through quickly.
+ */
 @keyframes view-in {
   from {
     opacity: 0;
+    transform: translateY(6px);
   }
 }
 


### PR DESCRIPTION
## What

Gives the loading spinner a delay and a minimum, and gives the page transition a little travel.

## Why

Switching pages read as a jolt rather than a change, and two things were making it.

**The spinner was drawn the instant a load started.** `key={viewKey}` remounts the column on every switch, so `useBrokerData` starts over — `loading: true`, then a request. Most of those requests finish well inside the time it takes to register a spinner: 18ms for a project's topics, 21ms for a queue listing, 36ms for a stream listing, all read off the status bar against their own containers. The spinner appeared and was gone again, which the eye reads as a flicker, not as loading.

**The fade was opacity-only.** Changing the whole column's opacity at once reads as a blink; there is nothing for the eye to follow.

## How

`BoardState` waits **200ms** before showing the spinner, and once shown holds it for **300ms**.

Both halves matter. With a delay alone, a 386ms read — an IBM MQ queue manager over mqweb, the slowest measured — shows the spinner for 186ms, which is the same flicker moved later. Inside the delay the board draws nothing and holds its space, so the column fading in is the whole of what moves, and nothing below shifts when the rows land.

The fade keeps `--mo-base` (180ms) and gains **6px of rise**. The duration is deliberately unchanged: this is a page people click through quickly, and the problem was never that it was too fast. The existing `--mo-ease-out` spends most of that distance early, so it lands rather than drifts. 4px was not enough to stop reading as a blink; 8px started to read as a slide.

The 30-second refresh is untouched — it goes through `refreshing`, which keeps the previous data on screen and never showed a spinner.

## Testing

`npm run type-check` and the full suite pass — 144 files, 1608 tests.

The policy lives in `spinnerTiming.ts` and is tested against the latencies the app actually sees, so tuning either constant back into a flash fails a test that names the family it would affect.

**One honest gap.** The spinner now renders from an effect, and this suite renders through `react-dom/server`, where effects do not run — so the spinner's own markup is no longer reachable by these tests. The four board tests that asserted it on first render were protecting something still true (a board that has not answered must not render as though it had) and now assert `aria-busy` instead, which holds throughout the delay.

## Related

Found while walking the UI after the drivers landed; the demo that compared the two is what the numbers were chosen from.