### PR TITLE
fix(connections): keep a field label against its own input

### DIFF
--- a/frontend/src/design/boards/connections/ConnectionForms.tsx
+++ b/frontend/src/design/boards/connections/ConnectionForms.tsx
@@ -26,11 +26,17 @@ function Fld({
       className="flex min-w-0 flex-col gap-1.5 text-xs"
       style={span ? { gridColumn: "1/3" } : undefined}
     >
-      {/* The label grows and the input sits at the bottom, so two fields side
-          by side line up whatever their hints do. Without this a hint that
-          wraps pushes its own input down and leaves its neighbour's floating
-          half a field above it. */}
-      <span className="flex-1 font-medium">
+      {/*
+        * The free space goes above the label, not below it.
+        *
+        * Both fields in a row are as tall as the taller hint, which is what
+        * lines their inputs up. Growing the label instead put that space
+        * between a short label and its own input: "连接名称" sat four lines
+        * clear of the box it names, while the wrapped hint beside it ran right
+        * down to its own. Pushing the pair down keeps the inputs aligned and
+        * the label against the thing it labels.
+        */}
+      <span className="mt-auto font-medium">
         {label} {hint != null && <span className="font-normal text-(--c-muted-2)">{hint}</span>}
       </span>
       {children}


### PR DESCRIPTION
## What

Moves the slack in a two-column form row from between the label and its input to above the label.

## Why

Two fields sharing a row are as tall as the taller hint — that is what lines their inputs up, and it works. What was wrong is which part absorbed the difference: the label grew, so the extra height landed *between* a short label and the box it names.

On the SQS form that put `连接名称` four lines clear of its input while the wrapped `AWS 区域` hint beside it ran right down to its own, and `Secret Access Key` did the same next to the three-line `Access Key ID` hint. The label and the input stopped reading as one thing.

## How

The label takes `mt-auto` instead of `flex-1`, so the free space in the cell goes above it and the label sits directly on top of its input. The inputs still align across the row — that part was never broken — and a full-width field, being alone in its row, is unchanged.

One change to the shared `Fld`, so all 171 fields are covered.

## Testing

`npm run type-check` and the full suite pass — 143 files, 1599 tests.

Worth looking at rather than reading: the SQS, Kinesis and IBM MQ forms are where the hints are longest, so they are where the gap was widest.