### PR TITLE
fix(connections): make the tile subtitle say one thing

### DIFF
--- a/frontend/src/design/boards/connections/NewConnectionDialog.tsx
+++ b/frontend/src/design/boards/connections/NewConnectionDialog.tsx
@@ -51,7 +51,18 @@ import {
 } from "./connectionDraft";
 import { draftInvalidReason } from "./connectionValidation";
 
-/** Version ranges printed under each tile in the 3a protocol picker. */
+/*
+ * The second line under each tile in the protocol picker.
+ *
+ * It says one thing: which releases this driver targets. Not how it reaches
+ * them - IBM MQ's mqweb REST and Solace's SEMP v2 are named in their own
+ * forms, where the address that uses them is typed, and repeating them here
+ * only made those two tiles twice the length of the rest.
+ *
+ * Three exceptions, each because the version alone would be a lie: ActiveMQ
+ * covers two products, and the four hosted services have no version a reader
+ * could act on. Keep it under ~17 characters; the first eight set the shape.
+ */
 const TILE: Record<ProtocolId, { name: string; versions: string }> = {
   rocketmq: { name: "RocketMQ", versions: "4.x / 5.x" },
   kafka: { name: "Kafka", versions: "3.x / 4.x" },
@@ -62,7 +73,7 @@ const TILE: Record<ProtocolId, { name: string; versions: string }> = {
   nats: { name: "NATS", versions: "2.x" },
   // One tile for two products. Which one is behind the console is the
   // driver's to work out, so asking here would only let a user get it wrong.
-  activemq: { name: "ActiveMQ", versions: "Classic 5/6 · Artemis 2.x" },
+  activemq: { name: "ActiveMQ", versions: "Classic · Artemis" },
   nsq: { name: "NSQ", versions: "1.x" },
   // No version to print: SQS is a managed service with one, whichever AWS
   // is running. What varies is the region, and that is a form field.
@@ -80,11 +91,11 @@ const TILE: Record<ProtocolId, { name: string; versions: string }> = {
   // Not managed: this one is a queue manager somebody runs, reached through
   // the web server beside it. The version printed is the mqweb server's REST
   // API rather than the product's, because that is what the driver speaks.
-  ibmmq: { name: "IBM MQ", versions: "9.1+ (mqweb REST)" },
+  ibmmq: { name: "IBM MQ", versions: "9.1+" },
   // Not managed either, and the version printed is SEMP's rather than the
   // broker's: v2 is what the driver speaks, and it is the half of the API
   // that has a config and a monitor tree instead of an XML RPC.
-  solace: { name: "Solace PubSub+", versions: "9.4+ (SEMP v2)" },
+  solace: { name: "Solace PubSub+", versions: "9.4+" },
 };
 
 /** What the probe last reported, drawn in the footer beside the test button. */


### PR DESCRIPTION
## What

Trims the second line under each protocol tile so it carries one kind of fact.

## Why

It ran from three to twenty-five characters and said three different things:

| | tile | line | what it was |
|---|---|---|---|
| 3–9 | the first eight | `4.x / 5.x`, `2.x`, `1.x` | a version range |
| **25** | ActiveMQ | `Classic 5/6 · Artemis 2.x` | two products *and* their versions |
| 7 | the four hosted | `managed` | not a version |
| **17** | IBM MQ | `9.1+ (mqweb REST)` | version *and* the API it connects over |
| **14** | Solace | `9.4+ (SEMP v2)` | the same |

The eight set the shape and the others each went their own way, so three tiles ran twice the length of everything around them.

The APIs in parentheses were the clearest waste: both are named in the very next step, in the form where the address that uses them is typed — `mqweb 服务器地址 … 本应用使用的两个 REST 接口都由它承载`, and Solace's SEMP port. The tile was repeating what the form explains.

## How

The line now says which releases the driver targets. `9.1+`, `9.4+`.

ActiveMQ keeps both product names and drops their versions — one tile covering Classic *and* Artemis is the thing a reader would otherwise get wrong, and the versions are in the docs. The four hosted services keep `managed`: they have no version anyone can act on, and inventing one would be worse than saying so.

Longest is now 17 characters, down from 25, and it is the one that earns it.

The rule is written above the table so the next vendor added does not start a fourth kind.

## Testing

`npm run type-check` and the full suite pass — 144 files, 1603 tests.

## Related

Based on #95, which is where these tiles are drawn.