### PR TITLE
fix(connections): move a field's hint under its control

### DIFF
--- a/frontend/src/design/boards/connections/ConnectionForms.test.tsx
+++ b/frontend/src/design/boards/connections/ConnectionForms.test.tsx
@@ -46,9 +46,14 @@ beforeAll(async () => {
     );
 });
 
-/** The markup of one field, from its hint to the end of that field's block. */
-function fieldAfter(html: string, hintKey: string): string {
-  const rest = html.split(hintKey)[1] ?? "";
+/**
+ * The markup of one field, from its label to the end of that field's block.
+ *
+ * Split on the closing tag as well: the label key is a prefix of its own hint
+ * key, so the bare key matches twice and the first half of the field is lost.
+ */
+function fieldAfter(html: string, labelKey: string): string {
+  const rest = html.split(`${labelKey}</span>`)[1] ?? "";
   return rest.slice(0, rest.indexOf("</div>"));
 }
 
@@ -56,7 +61,7 @@ describe("the RocketMQ connection form", () => {
   it("draws the namespace as a live field, not the placeholder it replaced", () => {
     const html = renderRocketMQForm("MQ_INST_1");
 
-    const namespace = fieldAfter(html, `${KEY}.namespaceHint`);
+    const namespace = fieldAfter(html, `${KEY}.namespace`);
     expect(namespace).toContain('value="MQ_INST_1"');
     // The attribute, not the substring: Tailwind's disabled: variants put the
     // word in every input's class list.
@@ -66,6 +71,21 @@ describe("the RocketMQ connection form", () => {
     // difference: the two fields beside it are still placeholders.
     expect(html).not.toContain("instanceId");
     expect(fieldAfter(html, `${KEY}.traceTopic`)).toContain('disabled=""');
+  });
+
+  it("puts a field's explanation under its control, not above it", () => {
+    // A hint on the label line ran the two together, and made the row as tall
+    // as the longest explanation in it - which left the short field beside it
+    // an empty band where its own label belonged.
+    const html = renderRocketMQForm("MQ_INST_1");
+
+    const label = html.indexOf(`${KEY}.namespace</span>`);
+    const input = html.indexOf('value="MQ_INST_1"');
+    const hint = html.indexOf(`${KEY}.namespaceHint`);
+
+    expect(label).toBeGreaterThan(-1);
+    expect(label).toBeLessThan(input);
+    expect(input).toBeLessThan(hint);
   });
 
   it("opens the advanced block by itself when a namespace is set", () => {

--- a/frontend/src/design/boards/connections/ConnectionForms.tsx
+++ b/frontend/src/design/boards/connections/ConnectionForms.tsx
@@ -8,7 +8,7 @@ import {
   SelectField,
 } from "@/components";
 
-/** Label (with optional grey hint) above the control. */
+/** Label above the control, with the grey explanation under it. */
 function Fld({
   label,
   hint,
@@ -27,19 +27,20 @@ function Fld({
       style={span ? { gridColumn: "1/3" } : undefined}
     >
       {/*
-        * The free space goes above the label, not below it.
+        * The hint sits under the control, not on the label line.
         *
-        * Both fields in a row are as tall as the taller hint, which is what
-        * lines their inputs up. Growing the label instead put that space
-        * between a short label and its own input: "连接名称" sat four lines
-        * clear of the box it names, while the wrapped hint beside it ran right
-        * down to its own. Pushing the pair down keeps the inputs aligned and
-        * the label against the thing it labels.
+        * Both cells in a row are as tall as the taller one, so an explanation
+        * that wraps to four lines has to spend that height somewhere. Above
+        * the input it spent it twice over: it ran the label and the prose into
+        * one paragraph, and it left the one-line field beside it an empty band
+        * where its own label should have been. Below, every label and every
+        * input in the row still line up and only the slack falls ragged.
         */}
-      <span className="mt-auto font-medium">
-        {label} {hint != null && <span className="font-normal text-(--c-muted-2)">{hint}</span>}
-      </span>
+      <span className="font-medium">{label}</span>
       {children}
+      {hint != null && (
+        <span className="text-[11px] leading-[1.6] text-(--c-muted-2)">{hint}</span>
+      )}
     </div>
   );
 }
@@ -47,7 +48,9 @@ function Fld({
 const GRID = {
   display: "grid",
   gridTemplateColumns: "1fr 1fr",
-  gap: "12px 14px",
+  // Rows are further apart than the 6px inside a field so a hint reads as
+  // belonging to the input above it rather than the label below.
+  gap: "16px 14px",
 } as const;
 
 const MONO = { fontSize: "11.5px" } as const;

--- a/frontend/src/i18n/locales/zh.json
+++ b/frontend/src/i18n/locales/zh.json
@@ -1198,7 +1198,7 @@
         },
         "pulsar": {
           "service": "服务地址",
-          "serviceHint": "收发",
+          "serviceHint": "收发消息都走这个地址",
           "admin": "管理 API",
           "adminHint": "Topic/租户管理",
           "auth": "认证方式",
@@ -1239,7 +1239,7 @@
           "brokerHint": "mqtt/ws",
           "version": "协议版本",
           "sessionExpiry": "会话过期",
-          "sessionExpiryHint": "5.0",
+          "sessionExpiryHint": "仅 5.0 可用",
           "advanced": "客户端 ID、心跳、清理会话、TLS 与管理 API",
           "note": "遗嘱消息与消息顺序不在这里设置",
           "versionHint": "两个版本是不同的线上协议",


### PR DESCRIPTION
## What

Field help text moves from the label line to under the control, in the shared `Fld` component — one change across all 171 fields in the 15 connection forms. Grid row gap goes 12px -> 16px so a hint reads as belonging to the input above it rather than the label below.

Two Chinese hints written as label suffixes are reworded to stand on their own line: `pulsar.serviceHint` (`收发`) and `mqtt.sessionExpiryHint` (`5.0`). The English strings were already full phrases and are unchanged.

## Why

Both cells in a grid row are as tall as the taller one, so an explanation that wraps to four lines has to spend that height somewhere. On the label line it spent it twice over:

- the label and the prose ran together into one paragraph, so there was no visible boundary between "AWS region" and the 81 characters explaining it;
- the one-line field beside it was pushed down, leaving an empty band where its own label should have been.

That empty band is the misalignment reported on the SQS form, and it is not specific to SQS: 126 of the 171 fields carry a hint, and 33 of the Chinese ones wrap past one line.

Under the control instead, every label and every input in a row line up, and only the slack falls ragged at the bottom of the shorter cell.

## How

`Fld` previously carried an `mt-auto` on the label to push the pair down and keep the inputs aligned. With the hint below the control that is no longer needed: the natural top alignment of the flex column does it.

Ragged bottoms remain where one cell's hint is much longer than its neighbour's. Fixing that would mean giving long-hint fields their own full-width row, which is per-form hand-tuning rather than one shared change; left out deliberately.

## Testing

`npm run check` — 145 files, 1613 tests.

New assertion pins the order (label < input < hint) in `ConnectionForms.test.tsx`. Verified it is not vacuous by reverting `Fld` to the old markup and confirming it fails.

The existing test helper walked forward from the hint to reach the input, which only worked while the hint came first. It now splits on the label plus its closing tag, because the label key is a prefix of its own hint key and the bare key matches twice.

Rendered SQS, Pub/Sub, Service Bus, RocketMQ, MQTT and IBM MQ side by side in zh and en, light and dark, covering Input, Segmented, Select and Switch controls.