### PR TITLE
fix(ui): explain the states that said nothing

### DIFF
--- a/frontend/src/components/detail-panel.tsx
+++ b/frontend/src/components/detail-panel.tsx
@@ -4,7 +4,7 @@ import { X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { useEnter } from "@/lib/motion";
+import { useEnter, useLeave } from "@/lib/motion";
 import { cn } from "@/lib/utils";
 
 /*
@@ -43,6 +43,7 @@ export function DetailPanel({
 }) {
   const ref = useRef<HTMLDivElement>(null);
   const state = useEnter();
+  useLeave(ref);
   const dismiss = useRef(onDismiss);
   dismiss.current = onDismiss;
 
@@ -71,7 +72,9 @@ export function DetailPanel({
     <div
       ref={ref}
       className={cn(
-        "mqs-slide-right absolute inset-y-0 right-0 z-10 flex flex-col overflow-hidden border-l bg-background shadow-[-16px_0_44px_rgba(0,0,0,0.13)]",
+        /* Two tight layers rather than one 44px blur, which laid a grey band a
+           finger wide across whatever list the sheet was describing. */
+        "mqs-slide-right absolute inset-y-0 right-0 z-10 flex flex-col overflow-hidden border-l bg-background shadow-[-10px_0_28px_-14px_rgba(0,0,0,0.22),-24px_0_48px_-24px_rgba(0,0,0,0.08)]",
         className,
       )}
       data-state={state}

--- a/frontend/src/components/kv.tsx
+++ b/frontend/src/components/kv.tsx
@@ -9,6 +9,10 @@ import { cn } from "@/lib/utils";
  * compression.gzip.level does not fit, and a grid cell does not clip, so the
  * key was painted straight over its own value. Both halves wrap rather than
  * overflow, for the case where neither fits.
+ *
+ * It has a ceiling too. Sized to its longest label alone, a Kafka broker's
+ * config list gave the keys 367px of a 407px sheet, and every value wrapped a
+ * character at a time down the 30px that was left.
  */
 export function KV({
   rows,
@@ -22,14 +26,16 @@ export function KV({
   return (
     <div
       className={cn(
-        "grid grid-cols-[minmax(92px,auto)_1fr] items-baseline gap-x-2.5 gap-y-[5px] text-xs",
+        "grid grid-cols-[fit-content(60%)_1fr] items-baseline gap-x-2.5 gap-y-[5px] text-xs",
         className,
       )}
       style={style}
     >
       {rows.map(([key, value], i) => (
         <Fragment key={i}>
-          <span className="min-w-0 break-words text-muted-foreground">{key}</span>
+          {/* An explicit min-width, not min-w-0: it is the column's floor, and
+              it keeps an unbreakable label from pushing past the ceiling. */}
+          <span className="min-w-[92px] break-words text-muted-foreground">{key}</span>
           <span className="min-w-0 break-words">{value}</span>
         </Fragment>
       ))}

--- a/frontend/src/design/DesignApp.tsx
+++ b/frontend/src/design/DesignApp.tsx
@@ -12,6 +12,7 @@ import {
 import type { Connection } from "@/design/data/connections";
 import { labelOf, pagesOf, type PageId } from "@/design/data/protocols";
 import { renderBoard, type BoardFocus } from "@/design/registry";
+import { PageGate } from "@/design/boards/misc/Unavailable";
 import {
   onTrayNavigate,
   openExternal,
@@ -458,11 +459,20 @@ export function DesignApp(): JSX.Element {
             connectionsBoard
           );
         }
-        return renderBoard(protocol, pagesOf(protocol).includes(page) ? page : "overview", {
-          onOpenAlertSettings: () => goto({ kind: "settings", section: "message" }),
-          onOpenPage: selectPage,
-          focus: focus?.value,
-        });
+        {
+          const shown = pagesOf(protocol).includes(page) ? page : "overview";
+          /* The sidebar opens a page the connection cannot answer rather than
+             greying it out, so something has to be there when it does. */
+          return (
+            <PageGate page={shown} labelKey={labelOf(protocol, shown)}>
+              {renderBoard(protocol, shown, {
+                onOpenAlertSettings: () => goto({ kind: "settings", section: "message" }),
+                onOpenPage: selectPage,
+                focus: focus?.value,
+              })}
+            </PageGate>
+          );
+        }
     }
   })();
 

--- a/frontend/src/design/boards/connections/NewConnectionDialog.tsx
+++ b/frontend/src/design/boards/connections/NewConnectionDialog.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Check, RefreshCw, X } from "lucide-react";
+import { Check, LoaderCircle, X } from "lucide-react";
+import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
@@ -45,6 +46,7 @@ import {
 import {
   emptyDraft,
   isDraftable,
+  probeKey,
   toDraft,
   toSubmission,
   type ProtocolDraft,
@@ -98,12 +100,18 @@ const TILE: Record<ProtocolId, { name: string; versions: string }> = {
   solace: { name: "Solace PubSub+", versions: "9.4+" },
 };
 
-/** What the probe last reported, drawn in the footer beside the test button. */
-type ProbeState =
-  | { kind: "idle" }
-  | { kind: "running" }
+/** What the probe last reported, and the settings it was reporting on. */
+type ProbeVerdict = { key: string } & (
   | { kind: "ok"; latency: string }
-  | { kind: "failed"; message: string };
+  | { kind: "failed"; message: string }
+);
+
+/**
+ * The shortest time a test stays on "testing", about one turn of the spinner.
+ * A probe answered in 10ms would otherwise flash it for a frame, and a second
+ * test that got the same answer would look like no test at all.
+ */
+const PROBE_MIN_MS = 600;
 
 /**
  * Board 3a with one form per protocol. The canvas drew a field set for every
@@ -147,7 +155,10 @@ export function NewConnectionDialog({
    */
   const [step, setStep] = useState<"protocol" | "form">(editing == null ? "protocol" : "form");
   const [search, setSearch] = useState("");
-  const [probe, setProbe] = useState<ProbeState>({ kind: "idle" });
+  const [verdict, setVerdict] = useState<ProbeVerdict | null>(null);
+  const [probing, setProbing] = useState(false);
+  // Bumped whenever the form is replaced, so an answer about the old one is dropped.
+  const probeRun = useRef(0);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -167,7 +178,7 @@ export function NewConnectionDialog({
     // edit where the protocol cannot change anyway.
     setStep(editing == null ? "protocol" : "form");
     setSearch("");
-    setProbe({ kind: "idle" });
+    resetProbe();
     setError(null);
     setSaving(false);
   }, [editing, initialProtocol, open]);
@@ -192,19 +203,39 @@ export function NewConnectionDialog({
 
   const invalid = useMemo(() => draftInvalidReason(draft, t), [draft, t]);
 
+  const draftKey = useMemo(() => probeKey(toSubmission(draft)), [draft]);
+  // A verdict on settings the form no longer holds says nothing about these.
+  const current = verdict?.key === draftKey ? verdict : null;
+
+  const resetProbe = () => {
+    probeRun.current += 1;
+    setVerdict(null);
+    setProbing(false);
+  };
+
   const runProbe = async () => {
-    if (invalid != null || onProbe == null) return;
-    setProbe({ kind: "running" });
+    if (invalid != null || onProbe == null || probing) return;
+    const run = ++probeRun.current;
+    const key = draftKey;
+    const started = performance.now();
+    setProbing(true);
+    let answer: ProbeVerdict;
     try {
       const submission = toSubmission(draft);
       const elapsed = await onProbe(submission.draft, submission.credentialsMode);
-      setProbe({
+      answer = {
+        key,
         kind: "ok",
         latency: elapsed < 1000 ? `${Math.round(elapsed)}ms` : `${(elapsed / 1000).toFixed(1)}s`,
-      });
+      };
     } catch (probeError) {
-      setProbe({ kind: "failed", message: formatErrorMessage(probeError) });
+      answer = { key, kind: "failed", message: formatErrorMessage(probeError) };
     }
+    const hold = PROBE_MIN_MS - (performance.now() - started);
+    if (hold > 0) await new Promise((resolve) => setTimeout(resolve, hold));
+    if (run !== probeRun.current) return;
+    setVerdict(answer);
+    setProbing(false);
   };
 
   const save = async () => {
@@ -270,7 +301,7 @@ export function NewConnectionDialog({
                         onClick={() => {
                           if (!isDraftable(p)) return;
                           setDraft(emptyDraft(p));
-                          setProbe({ kind: "idle" });
+                          resetProbe();
                           setError(null);
                           setStep("form");
                         }}
@@ -403,37 +434,62 @@ export function NewConnectionDialog({
         />
       )}
 
-        <DialogFooter className="items-center">
-          <Button
-            variant="outline"
-            disabled={invalid != null || probe.kind === "running"}
-            onClick={runProbe}
-          >
-            {probe.kind === "running" && <Spinner />}
-            {t("page.connections.dialogTest")}
-          </Button>
-          <ProbeResult state={probe} />
-          <span className="flex-1" />
-          {/* The blocking reason belongs beside the button it blocks, not in a
-              toast that appears after the click that did nothing. */}
-          {(invalid ?? error) != null && (
-            <span
-              className={
-                "max-w-80 text-right text-xs " +
-                (error != null ? "text-(--c-err)" : "text-muted-foreground")
-              }
-            >
-              {error ?? invalid}
-            </span>
+        {/* One box with the footer, so the dialog's gap opens with the reason
+            instead of arriving at full size before it. */}
+        <div>
+          {verdict?.kind === "failed" && (
+            <div className="mqs-probe-reveal">
+              <div>
+                {/* Shown, not hovered: a title attribute is no tooltip on
+                    WKWebView, and this is what the test exists to produce.
+                    Dimmed rather than dropped once the form moves on, because
+                    it is what somebody reads while correcting it. */}
+                <Alert
+                  className={cn(
+                    "mb-3.5 border-transparent bg-(--c-err-bg) px-3 py-2 transition-opacity duration-(--mo-base)",
+                    (probing || current == null) && "opacity-50",
+                  )}
+                >
+                  <AlertDescription className="text-xs text-(--c-err-text) [overflow-wrap:anywhere]">
+                    {verdict.message}
+                  </AlertDescription>
+                </Alert>
+              </div>
+            </div>
           )}
-          <Button variant="outline" onClick={onClose}>
-            {t("common.cancel")}
-          </Button>
-          <Button disabled={invalid != null || saving} onClick={save}>
-            {saving && <Spinner />}
-            {t(editing != null ? "page.connections.dialogSaveOnly" : "page.connections.dialogSave")}
-          </Button>
-        </DialogFooter>
+          <DialogFooter className="items-center">
+            <Button
+              variant="outline"
+              disabled={invalid != null}
+              aria-busy={probing || undefined}
+              className="active:scale-[0.97] aria-busy:cursor-progress"
+              onClick={runProbe}
+            >
+              {t("page.connections.dialogTest")}
+            </Button>
+            <ProbeStatus probing={probing} verdict={current} />
+            <span className="flex-1" />
+            {/* The blocking reason belongs beside the button it blocks, not in a
+                toast that appears after the click that did nothing. */}
+            {(invalid ?? error) != null && (
+              <span
+                className={
+                  "max-w-80 text-right text-xs " +
+                  (error != null ? "text-(--c-err)" : "text-muted-foreground")
+                }
+              >
+                {error ?? invalid}
+              </span>
+            )}
+            <Button variant="outline" onClick={onClose}>
+              {t("common.cancel")}
+            </Button>
+            <Button disabled={invalid != null || saving} onClick={save}>
+              {saving && <Spinner />}
+              {t(editing != null ? "page.connections.dialogSaveOnly" : "page.connections.dialogSave")}
+            </Button>
+          </DialogFooter>
+        </div>
         </>
       )}
       </DialogContent>
@@ -441,53 +497,34 @@ export function NewConnectionDialog({
   );
 }
 
-function ProbeResult({ state }: { state: ProbeState }) {
+/**
+ * The answer to 测试连接, beside the button that asked for it.
+ *
+ * The whole exchange happens here rather than in the button: the button keeps
+ * its label and width, so nothing next to it shifts when it is pressed, and
+ * there is one spinner instead of one in the button and another beside it.
+ */
+function ProbeStatus({ probing, verdict }: { probing: boolean; verdict: ProbeVerdict | null }) {
   const { t } = useTranslation();
-  if (state.kind === "idle") return null;
-
-  const style = {
-    display: "inline-flex",
-    alignItems: "center",
-    gap: "5px",
-    fontSize: "11.5px",
-    maxWidth: "260px",
-  } as const;
-
-  if (state.kind === "running") {
-    return (
-      <span style={{ ...style, color: "var(--c-muted)" }}>
-        <RefreshCw size={13} className="mqs-turning" aria-hidden />
-        {t("page.connections.testing")}
-      </span>
-    );
-  }
-  if (state.kind === "ok") {
-    return (
-      <span style={{ ...style, color: "var(--c-ok-text)" }}>
-        <Check size={13} aria-hidden />
-        {t("page.connections.probeOk", { latency: state.latency })}
-      </span>
-    );
-  }
-  /*
-   * The reason is shown, not hovered.
-   *
-   * It used to live in a title attribute, which on WKWebView is no tooltip at
-   * all - so a failed test said "could not connect" and nothing else, and the
-   * one piece of information the button exists to produce was unreachable.
-   */
   return (
-    <span
-      style={{ ...style, color: "var(--c-err)", alignItems: "flex-start" }}
-      title={state.message}
-    >
-      <X size={13} aria-hidden style={{ flex: "none", marginTop: "2px" }} />
-      <span style={{ minWidth: 0 }}>
-        {t("page.connections.probeFailed")}
-        <span style={{ display: "block", color: "var(--c-muted)", overflowWrap: "anywhere" }}>
-          {state.message}
+    <span role="status" className="inline-flex min-w-0 items-center">
+      {probing ? (
+        <span className="mqs-probe-in inline-flex items-center gap-1.5 text-xs text-muted-foreground">
+          <LoaderCircle className="mqs-turning size-3.5" aria-hidden />
+          {t("page.connections.testing")}
         </span>
-      </span>
+      ) : verdict?.kind === "ok" ? (
+        <span className="mqs-probe-in inline-flex h-6 items-center gap-1.5 rounded-full bg-(--c-ok-tint) px-2.5 text-xs font-medium text-(--c-ok-text)">
+          <Check className="mqs-probe-mark size-3.5" strokeWidth={2.5} aria-hidden />
+          {t("page.connections.probeOkShort")}
+          <span className="font-normal tabular-nums opacity-70">{verdict.latency}</span>
+        </span>
+      ) : verdict?.kind === "failed" ? (
+        <span className="mqs-probe-in inline-flex h-6 items-center gap-1.5 rounded-full bg-(--c-err-bg) px-2.5 text-xs font-medium text-(--c-err-text)">
+          <X className="mqs-probe-mark size-3.5" strokeWidth={2.5} aria-hidden />
+          {t("page.connections.probeFailed")}
+        </span>
+      ) : null}
     </span>
   );
 }

--- a/frontend/src/design/boards/connections/connectionDraft.test.ts
+++ b/frontend/src/design/boards/connections/connectionDraft.test.ts
@@ -23,7 +23,7 @@ import {
   type GooglePubSubDraft,
   type AzureServiceBusDraft,
 } from "./ConnectionForms";
-import { emptyDraft, isDraftable, toDraft, toSubmission, type ProtocolDraft } from "./connectionDraft";
+import { emptyDraft, isDraftable, probeKey, toDraft, toSubmission, type ProtocolDraft } from "./connectionDraft";
 import { PROTOCOLS, type ProtocolId } from "@/design/data/protocols";
 
 const rocketmq = (value: RocketMQDraft): ProtocolDraft => ({ protocol: "rocketmq", value });
@@ -31,6 +31,30 @@ const rabbitmq = (value: RabbitMQDraft): ProtocolDraft => ({ protocol: "rabbitmq
 const kafka = (value: KafkaDraft): ProtocolDraft => ({ protocol: "kafka", value });
 const pulsar = (value: PulsarDraft): ProtocolDraft => ({ protocol: "pulsar", value });
 const redis = (value: RedisDraft): ProtocolDraft => ({ protocol: "redis", value });
+
+/**
+ * A connection test answers for the settings it ran against and no others. The
+ * name, group and remark are not among them: a result that vanished on every
+ * keystroke in the name field would teach people to stop reading it.
+ */
+describe("the key a connection test is recorded against", () => {
+  const tested = (): KafkaDraft => ({
+    ...emptyKafkaDraft(),
+    name: "orders",
+    endpoints: "127.0.0.1:9092",
+  });
+  const keyOf = (value: KafkaDraft) => probeKey(toSubmission(kafka(value)));
+
+  it("outlives renaming, regrouping and annotating the connection", () => {
+    expect(keyOf({ ...tested(), name: "orders-prod", group: "prod", remark: "primary" }))
+      .toBe(keyOf(tested()));
+  });
+
+  it("changes with where the connection goes and how long it waits", () => {
+    expect(keyOf({ ...tested(), endpoints: "127.0.0.1:9093" })).not.toBe(keyOf(tested()));
+    expect(keyOf({ ...tested(), timeoutSec: 42 })).not.toBe(keyOf(tested()));
+  });
+});
 
 /**
  * Both halves of an ACL pair are stored encrypted and neither comes back, so

--- a/frontend/src/design/boards/connections/connectionDraft.ts
+++ b/frontend/src/design/boards/connections/connectionDraft.ts
@@ -245,6 +245,14 @@ export function toSubmission(draft: ProtocolDraft): Submission {
   }
 }
 
+/**
+ * What a connection test depends on, as one comparable string: everything the
+ * probe sends except the fields that only label the connection.
+ */
+export function probeKey({ draft, credentialsMode }: Submission): string {
+  return JSON.stringify({ ...draft, name: "", group: "", remark: "", credentialsMode });
+}
+
 /** Reads a stored profile back into its own form's field set. */
 export function toDraft(profile: ConnectionProfile): ProtocolDraft {
   switch (profile.kind) {

--- a/frontend/src/design/boards/misc/Unavailable.test.tsx
+++ b/frontend/src/design/boards/misc/Unavailable.test.tsx
@@ -1,0 +1,93 @@
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import { Capability } from "@bindings/model/models";
+
+/*
+ * A page the connection cannot answer has to say so where the user went.
+ *
+ * The sidebar used to swallow the click on a degraded entry, so the reason the
+ * driver reported was reachable only by hovering it for half a second. What a
+ * user saw was a grey row that did nothing, which reads as a broken app rather
+ * than as a cluster with a feature switched off. The entry opens now, and this
+ * is what it has to land on.
+ */
+vi.mock("@/mq/ConnectionScope", () => ({
+  useConnectionScope: () => ({ id: 1, kind: "kafka", key: "k1", online: true }),
+}));
+
+const capabilities = vi.hoisted(() => ({ current: null as unknown }));
+vi.mock("@/mq/capabilities", () => ({ useCapabilities: () => capabilities.current }));
+
+let render: (element: React.ReactElement) => string;
+let PageGate: typeof import("./Unavailable").PageGate;
+
+beforeAll(async () => {
+  const [server, gate, i18n] = await Promise.all([
+    import("react-dom/server"),
+    import("./Unavailable"),
+    import("@/i18n"),
+  ]);
+  await i18n.default.changeLanguage("zh");
+  render = (node) => server.renderToStaticMarkup(node);
+  PageGate = gate.PageGate;
+});
+
+/* A closed list rather than "anything not degraded": the ACL page asks for any
+   one of five capabilities, and a stub that says yes to all of them is never
+   the case under test. */
+const state = (supported: Capability[], degraded: Partial<Record<Capability, string>>) => ({
+  has: (capability: Capability) => supported.includes(capability),
+  degradedReason: (capability: Capability) => degraded[capability],
+  caveat: () => undefined,
+  loading: false,
+});
+
+const board = <div>BOARD</div>;
+
+describe("a page whose capabilities all came back degraded", () => {
+  it("opens on the driver's reason, not on the board", () => {
+    capabilities.current = state([Capability.CapDestinationList], {
+      [Capability.CapAccessDirectory]: "mq.kafka.degraded.accessControl",
+    });
+
+    const html = render(
+      <PageGate page="acl" labelKey="board.acl.kafka.title">
+        {board}
+      </PageGate>,
+    );
+
+    expect(html).not.toContain("BOARD");
+    // The sentence, not the key: a driver reports keys, and a page showing
+    // "mq.kafka.degraded.accessControl" explains nothing to anybody.
+    expect(html).not.toContain("mq.kafka.degraded.accessControl");
+    expect(html).toContain("authorizer");
+    expect(html).toContain("SECURITY_DISABLED");
+  });
+
+  it("passes a reason that has no translation through as written", () => {
+    capabilities.current = state([Capability.CapDestinationList], {
+      [Capability.CapAccessDirectory]: "something nobody wrote a key for",
+    });
+
+    const html = render(
+      <PageGate page="acl" labelKey="board.acl.kafka.title">
+        {board}
+      </PageGate>,
+    );
+
+    expect(html).toContain("something nobody wrote a key for");
+  });
+});
+
+describe("a page the connection can answer", () => {
+  it("draws the board and nothing else", () => {
+    capabilities.current = state([Capability.CapAccessDirectory], {});
+
+    const html = render(
+      <PageGate page="acl" labelKey="board.acl.kafka.title">
+        {board}
+      </PageGate>,
+    );
+
+    expect(html).toBe("<div>BOARD</div>");
+  });
+});

--- a/frontend/src/design/boards/misc/Unavailable.tsx
+++ b/frontend/src/design/boards/misc/Unavailable.tsx
@@ -1,0 +1,57 @@
+import type { ReactNode } from "react";
+import { useTranslation } from "react-i18next";
+import { ShieldOff } from "lucide-react";
+import { Page, PageHeader } from "@/design/shell/Page";
+import { Notice } from "@/design/boards/BoardState";
+import { useCapabilities } from "@/mq/capabilities";
+import { useConnectionScope } from "@/mq/ConnectionScope";
+import { navAvailability } from "@/mq/navigation";
+import { isI18nKey } from "@/lib/utils";
+
+/**
+ * What a page opens on when the connection cannot answer it.
+ *
+ * The endpoint said why - a cluster running no authorizer, a plugin nobody
+ * installed, a tier that cannot be reached - and that sentence is the whole
+ * point of letting the entry be clicked. Drivers report it as a translation
+ * key so that one Go driver's answer reads in both languages; one that is not
+ * a key is passed through as written.
+ */
+export function Unavailable({ labelKey, reason }: { labelKey: string; reason: string }) {
+  const { t } = useTranslation();
+  return (
+    <Page>
+      <PageHeader title={t(labelKey)} />
+      <Notice icon={<ShieldOff size={22} aria-hidden />} title={t("board.unavailable.title")}>
+        {isI18nKey(reason) ? t(reason) : reason}
+      </Notice>
+    </Page>
+  );
+}
+
+/**
+ * The board, or the reason there is none to draw.
+ *
+ * Boards that know the limit draw it better themselves - Kafka's ACL page
+ * keeps its tabs and explains which system is off - and they still do: this
+ * stands in only where every capability the page asks for came back degraded,
+ * which is exactly when the board behind it would otherwise report a failed
+ * read for something that is not a failure.
+ */
+export function PageGate({
+  page,
+  labelKey,
+  children,
+}: {
+  page: string;
+  labelKey: string;
+  children: ReactNode;
+}): ReactNode {
+  const capabilities = useCapabilities();
+  const { online } = useConnectionScope();
+  const nav = navAvailability(capabilities, online);
+
+  const reason = nav.disabled(page) ? nav.reason(page) : undefined;
+  if (reason == null) return children;
+  return <Unavailable labelKey={labelKey} reason={reason} />;
+}

--- a/frontend/src/design/shell/CommandPalette.tsx
+++ b/frontend/src/design/shell/CommandPalette.tsx
@@ -96,7 +96,10 @@ export function CommandPalette({
     if (protocol != null) {
       for (const group of PROTOCOLS[protocol].nav) {
         for (const entry of group.items) {
-          if (!nav.visible(entry.id) || nav.disabled(entry.id)) continue;
+          /* Listed even where the connection cannot answer it: the page opens
+             on the reason now, and a command that is quietly absent is the
+             same dead end the sidebar used to be. */
+          if (!nav.visible(entry.id)) continue;
           const label = t(entry.label);
           if (!matches(label, entry.id)) continue;
           out.push({

--- a/frontend/src/design/shell/Sidebar.test.tsx
+++ b/frontend/src/design/shell/Sidebar.test.tsx
@@ -72,26 +72,24 @@ describe("the sidebar's reason for a blocked entry", () => {
   });
 
   /*
-   * The reason has to be reachable, not merely rendered.
+   * The reason has to be reachable, and a hover is not reachable enough.
    *
-   * These entries were `disabled`, and a disabled button receives no pointer
-   * events - so the tooltip carrying the reason never appeared, and the whole
-   * explanation was computed, translated and invisible. Found by hovering a
-   * degraded entry in the running app for five seconds and getting nothing.
-   *
-   * The two assertions are the fix: the entry still reads as disabled to
-   * assistive technology and to the stylesheet, and is not the attribute that
-   * suppresses the hover.
+   * These entries were `disabled` first, which took the pointer events and the
+   * tooltip with them; then `aria-disabled` with the click guarded, which left
+   * a grey row that did nothing when clicked. Both read as a broken app - the
+   * second one to a user, in as many words. The entry opens now, PageGate
+   * lands it on the reason, and the mark is what says there is one to read.
    */
-  it("leaves a blocked entry hoverable, or nobody ever reads the reason", () => {
+  it("opens a blocked entry rather than swallowing the click", () => {
     capabilities.current = state({
       [Capability.CapAccessDirectory]: "mq.kafka.degraded.accessControl",
     });
 
     const html = render(<Sidebar protocol="kafka" active="overview" />);
 
-    expect(html).toContain('aria-disabled="true"');
-    expect(html).not.toContain("disabled=\"\"");
+    expect(html).not.toContain("aria-disabled");
+    expect(html).not.toContain('disabled=""');
+    expect(html).toContain("nidot");
   });
 
   // A reason that is not a key must survive rather than disappear: i18next

--- a/frontend/src/design/shell/Sidebar.tsx
+++ b/frontend/src/design/shell/Sidebar.tsx
@@ -87,8 +87,16 @@ export function Sidebar({
                 <div className="gl">{t(group.label)}</div>
               )}
               {items.map(({ id, icon: Icon, label }) => {
-                const disabled = nav.disabled(id);
-                const reason = disabled ? nav.reason(id) : undefined;
+                /*
+                 * A page the endpoint cannot answer is still worth opening.
+                 * The board behind it says what is off and why - a cluster
+                 * running no authorizer, a plugin nobody installed - while an
+                 * entry that greys out and then ignores the click reads as a
+                 * broken app. Being offline disables nothing here already, and
+                 * this is the same argument.
+                 */
+                const limited = nav.disabled(id);
+                const reason = limited ? nav.reason(id) : undefined;
                 /*
                  * The tooltip is a component rather than the title attribute.
                  *
@@ -108,14 +116,8 @@ export function Sidebar({
                   <button
                     key={id}
                     type="button"
-                    /* aria-disabled rather than disabled, because the reason
-                     below is the whole point of keeping the entry: a disabled
-                     button receives no pointer events, so its title tooltip
-                     never appears and the explanation is computed, translated
-                     and then invisible. The click is guarded instead. */
-                    aria-disabled={disabled || undefined}
                     aria-current={id === active ? "page" : undefined}
-                    className={cn("ni", id === active && "on")}
+                    className={cn("ni", id === active && "on", limited && "lim")}
                     /* The label is the only thing naming the icon once it is
                      gone; a blocked entry adds why it cannot be opened. The
                      reason is a translation key - drivers report keys, not
@@ -123,13 +125,14 @@ export function Sidebar({
                      degraded entry explained itself as
                      "mq.kafka.degraded.accessControl". */
                     title={hint || undefined}
-                    onClick={() => {
-                      if (disabled) return;
-                      onSelect?.(id);
-                    }}
+                    onClick={() => onSelect?.(id)}
                   >
                     <span className="nic">
                       <Icon size={ICON} aria-hidden />
+                      {/* A mark, because a muted label on its own reads as
+                          dead rather than as limited, and a reason nobody
+                          suspects is there is a reason nobody hovers for. */}
+                      {limited && <span className="nidot" aria-hidden />}
                     </span>
                     <span className="nil">{t(label)}</span>
                   </button>

--- a/frontend/src/design/tokens.css
+++ b/frontend/src/design/tokens.css
@@ -133,15 +133,20 @@
    * Motion. Every duration in the shell is one of these, so 界面过渡动画 has a
    * single place to turn them off -- see the switch at the foot of the file.
    * Three lengths: `fast` for a colour under the cursor, `base` for anything
-   * that enters or leaves, `slow` for the two that cross the window.
+   * that enters or leaves, `slow` for the detail sheet, which crosses its own
+   * width to get there.
    */
   --mo-fast: 0.12s;
   --mo-base: 0.18s;
+  --mo-slow: 0.28s;
   /* One full turn of the update icon, which is a gesture rather than a fade. */
   --mo-turn: 0.6s;
   /* Decelerating, so a panel arrives rather than stops. */
   --mo-ease: cubic-bezier(0.32, 0.72, 0, 1);
   --mo-ease-out: cubic-bezier(0.16, 1, 0.3, 1);
+  /* Accelerating, for the way out: easing to a stop on the way off screen
+     reads as hesitation. */
+  --mo-ease-in: cubic-bezier(0.32, 0, 0.67, 0);
 }
 
 /*
@@ -261,6 +266,46 @@
 /* Anything else waiting on Go turns the same way, at the same speed. */
 .mqs-turning {
   animation: mqs-turn var(--mo-turn) linear infinite;
+}
+/*
+ * 测试连接's answer slides out from the button rather than swapping in place,
+ * so a second test that gets the same answer still visibly got one.
+ */
+.mqs-probe-in {
+  animation: mqs-probe-in var(--mo-base) var(--mo-ease-out);
+}
+@keyframes mqs-probe-in {
+  from {
+    opacity: 0;
+    transform: translateX(-4px);
+  }
+}
+.mqs-probe-mark {
+  animation: mqs-probe-mark var(--mo-base) var(--mo-ease-out);
+}
+@keyframes mqs-probe-mark {
+  from {
+    transform: scale(0.4);
+  }
+}
+/*
+ * A failed test's reason opens rather than appears: the dialog is centred, so a
+ * block arriving at full height would jolt the whole form by half of it.
+ */
+.mqs-probe-reveal {
+  display: grid;
+  grid-template-rows: 1fr;
+  animation: mqs-probe-reveal var(--mo-base) var(--mo-ease-out);
+}
+.mqs-probe-reveal > * {
+  min-height: 0;
+  overflow: hidden;
+}
+@keyframes mqs-probe-reveal {
+  from {
+    grid-template-rows: 0fr;
+    opacity: 0;
+  }
 }
 /*
  * A control small enough to live inside a field's grey hint line. It borrows
@@ -413,12 +458,38 @@
   opacity: 0.5;
 }
 /*
+ * A page the endpoint answers with a reason rather than with data. It opens -
+ * what it opens on is the reason - so it is drawn as limited rather than as
+ * dead: muted, and marked so that there is something to hover.
+ */
+.ni.lim {
+  color: var(--c-muted);
+}
+.ni.lim .nic {
+  opacity: 0.6;
+}
+/* The selected row wins its colour back: muted text on the dark fill is
+   unreadable, and a limited page can be the one you are on. */
+.ni.lim.on {
+  color: var(--c-bg);
+}
+.nidot {
+  position: absolute;
+  top: 0;
+  right: -1px;
+  width: 5px;
+  height: 5px;
+  border-radius: 9999px;
+  background: var(--c-warn);
+}
+/*
  * Holds the canvas's 16px icon column now that what sits in it is an SVG and
  * not a Unicode symbol. The rail width is measured off this; Sidebar's own
  * ICON has to stay 16 to match.
  */
 .nic {
   width: 16px;
+  position: relative;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -1218,7 +1289,14 @@ html[data-animations='off'] .mqs-toaster [data-sonner-toast] {
 /*
  * The detail sheet, coming in off the right edge it is docked to. It carries a
  * `data-state` that lib/motion's useEnter flips one frame after mount, so the
- * transition has a start value to run from.
+ * transition has a start value to run from, and that useLeave's copy flips
+ * back to leave on.
+ *
+ * The whole way in from the edge, rather than the 16px nudge this was: across
+ * 440px of panel the nudge was lost and what was left was a fade, which reads
+ * as the sheet appearing rather than arriving. In on the decelerating curve,
+ * out faster on the accelerating one. The fade comes along so that the
+ * shadow's tail is not sitting at the window's edge before the panel is.
  *
  * The last of what was once a set: a scrim, a modal that rose into the middle
  * and a menu that dropped from its trigger went with the move to shadcn, whose
@@ -1226,14 +1304,17 @@ html[data-animations='off'] .mqs-toaster [data-sonner-toast] {
  */
 .mqs-slide-right {
   opacity: 0;
-  transform: translateX(16px);
+  transform: translateX(100%);
   transition:
-    opacity var(--mo-base) var(--mo-ease),
-    transform var(--mo-base) var(--mo-ease);
+    opacity var(--mo-base) var(--mo-ease-in),
+    transform var(--mo-base) var(--mo-ease-in);
 }
 .mqs-slide-right[data-state='open'] {
   opacity: 1;
   transform: none;
+  transition:
+    opacity var(--mo-fast) linear,
+    transform var(--mo-slow) var(--mo-ease);
 }
 
 /*
@@ -1312,6 +1393,7 @@ html[data-animations='off'] .mqs-toaster [data-sonner-toast] {
 :root[data-animations='off'] {
   --mo-fast: 0s;
   --mo-base: 0s;
+  --mo-slow: 0s;
   --mo-turn: 0s;
 }
 :root[data-animations='off'] *,

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1060,6 +1060,7 @@
       "dialogTitleEdit": "Edit connection",
       "dialogSaveOnly": "Save",
       "probeOk": "Connected · {{latency}}",
+      "probeOkShort": "Connected",
       "probeFailed": "Could not connect",
       "soon": "Coming soon",
       "protocolSoonHint": "The dimmed protocols have no driver yet; they open up in later versions.",
@@ -1350,6 +1351,9 @@
       "line2": "Once one is drawn it can be built from the same shell and components as everything else.",
       "subtitle": "{{protocol}} · this page has no artboard in the design yet",
       "note": "“{{page}}” is defined in the sidebar and nowhere else yet."
+    },
+    "unavailable": {
+      "title": "Not available on this connection"
     },
     "overview": {
       "kafka": {

--- a/frontend/src/i18n/locales/zh.json
+++ b/frontend/src/i18n/locales/zh.json
@@ -1060,6 +1060,7 @@
       "dialogTitleEdit": "编辑连接",
       "dialogSaveOnly": "保存",
       "probeOk": "连接成功 · {{latency}}",
+      "probeOkShort": "连接成功",
       "probeFailed": "连接失败",
       "soon": "开发中",
       "protocolSoonHint": "变灰的协议还没有驱动，会在后续版本里陆续开放。",
@@ -1350,6 +1351,9 @@
       "line2": "补稿后按同一套 shell 与组件实现即可。",
       "subtitle": "{{protocol}} · 本页在设计稿中尚无画板",
       "note": "「{{page}}」目前只在侧边栏中定义。"
+    },
+    "unavailable": {
+      "title": "这项功能在当前连接上不可用"
     },
     "overview": {
       "kafka": {

--- a/frontend/src/lib/motion.ts
+++ b/frontend/src/lib/motion.ts
@@ -6,13 +6,12 @@
  * than shortened and a transition can never be caught mid-way.
  *
  * What CSS cannot do on its own is give an element that has just mounted a
- * closed frame to animate out of. That is all this is now. It used to hold a
- * closing overlay mounted for its exit as well, for a scrim, a modal and a
- * menu that tokens.css no longer draws: shadcn's overlays arrived with their
- * own presence, and Radix holds a panel for its exit itself.
+ * closed frame to animate out of, or keep one that has just unmounted on
+ * screen long enough to leave. Radix does both for shadcn's overlays; the two
+ * hooks here are for the detail sheet, which is ours.
  */
 
-import { useEffect, useState } from "react";
+import { useEffect, useLayoutEffect, useState, type RefObject } from "react";
 
 /**
  * The opening element renders one frame closed so the transition has a start
@@ -38,12 +37,66 @@ export type PresenceState = "open" | "closed";
 /**
  * The closed first frame an entering overlay needs to start from, for one its
  * caller mounts and unmounts directly instead of holding an `open` flag -- the
- * detail sheets, which every board renders behind its own `selected &&`. There
- * is no exit to hold for. Goes on the element as `data-state`, which the
- * `.mqs-slide-right` rule in tokens.css animates between.
+ * detail sheets, which every board renders behind its own `selected &&`. Goes
+ * on the element as `data-state`, which the `.mqs-slide-right` rule in
+ * tokens.css animates between; the way out is useLeave's.
  */
 export function useEnter(): PresenceState {
   const [state, setState] = useState<PresenceState>("closed");
   useEffect(() => afterFirstPaint(() => setState("open")), []);
   return state;
+}
+
+/**
+ * The way out for an element its caller unmounts directly. React removes such
+ * an element in the same commit that drops it from the tree, so there is
+ * nothing left to animate: what leaves is a copy, taken just before, put back
+ * where the element stood and switched to `data-state="closed"`.
+ *
+ * The copy is inert and goes when its transition ends. Scroll offsets are
+ * carried across, or a sheet read halfway down would jump to its top on the
+ * way out.
+ */
+export function useLeave(ref: RefObject<HTMLElement | null>): void {
+  useLayoutEffect(() => {
+    const element = ref.current;
+    const parent = element?.parentNode;
+    if (element == null || parent == null) return;
+    // A copy still leaving from the last close would slide out across this one.
+    parent.querySelectorAll(":scope > [data-leaving]").forEach((copy) => copy.remove());
+
+    // Layout cleanup runs before React detaches the element, so it can still be read.
+    return () => {
+      if (document.documentElement.dataset.animations === "off") return;
+      const next = element.nextSibling;
+      const copy = element.cloneNode(true) as HTMLElement;
+      const offsets: [number, number][] = [];
+      element.querySelectorAll("*").forEach((node, i) => {
+        if (node.scrollTop > 0) offsets.push([i, node.scrollTop]);
+      });
+
+      queueMicrotask(() => {
+        // Still attached means StrictMode's rehearsal; a detached parent means
+        // the whole board went, and there is nowhere to leave from.
+        if (element.isConnected || !parent.isConnected) return;
+        copy.dataset.leaving = "";
+        copy.inert = true;
+        parent.insertBefore(copy, next?.parentNode === parent ? next : null);
+        const nodes = copy.querySelectorAll("*");
+        for (const [i, top] of offsets) {
+          const node = nodes[i];
+          if (node != null) node.scrollTop = top;
+        }
+        // Read back so the open frame is committed and the change below runs from it.
+        copy.getBoundingClientRect();
+        copy.dataset.state = "closed";
+        const remove = () => copy.remove();
+        copy.addEventListener("transitionend", (event) => {
+          if (event.target === copy) remove();
+        });
+        // A window that is not being painted never ends the transition.
+        window.setTimeout(remove, 1000);
+      });
+    };
+  }, [ref]);
 }


### PR DESCRIPTION
## What

Three states that answered a click with nothing now say what is going on.

**The connection test.** The button keeps its label and width instead of
growing a spinner under the pointer, and the status lives in one place beside
it. A verdict is held until the spinner has turned once, so a 10ms probe still
reads as a test that ran, while a slow one shows the moment it lands. A
failure's reason opens above the footer instead of squeezing in beside the
buttons, and a verdict is dropped once the settings it was run against change.

**The detail sheet.** Its label column was sized to the longest key it held,
which left a Kafka broker's 320-entry config list with 29px for its values:
`advertised.listeners` wrapped one character at a time down 19 lines. The
column has a ceiling now as well as a floor. The sheet also crosses its own
width on the way in rather than nudging 16px, and has a way out at all.

**A page the connection cannot answer.** The sidebar greyed the entry out and
swallowed the click, so the reason the driver reported - a Kafka cluster
running no authorizer, a RabbitMQ plugin nobody installed - could only be read
by hovering the entry for half a second. The entry opens now and lands on that
reason, and carries a mark so the limit is legible before the click.

## Why

Reported while using the app: the greyed-out ACL entry "makes users think we
have a bug", and the test-connection click felt crude. The board behind that
entry already explained itself - nothing could reach it. This is the same
reasoning `navAvailability` already applies to being offline: every board
renders its own state, which says more than a dead sidebar does.

## How

- `KV` caps the label column with `fit-content(60%)`; the 92px floor moves to a
  `min-width` on the label, so an unbreakable key cannot push past the ceiling.
- `useLeave` (`lib/motion.ts`) clones the sheet in its layout effect's cleanup,
  which runs while the node is still attached, and transitions the copy out.
  Three guards: StrictMode's rehearsal (the element is still connected), a
  parent that is leaving too, and motion turned off.
- `PageGate` stands in for a board when every capability the page asks for came
  back degraded, so no family lands on a failed read for something that is not
  a failure. Boards that explain the limit themselves still do.
- The sidebar entry is no longer `aria-disabled` and no longer guards its own
  click. The command palette lists those pages again for the same reason.

## Testing

- `npm run type-check`, `npx vitest run` (145 files, 1614 tests) and
  `npm run build` all pass. Three tests are new; `Sidebar.test.tsx` swaps the
  contract it pinned, which used to require `aria-disabled`.
- The dialog was driven through a throwaway preview page: a 10ms answer appears
  at 610ms and a 1500ms answer at 1509ms; the footer's three buttons hold
  `x=247 w=93.1` across idle, testing and settled; the failure reason grows the
  dialog 372.8 -> 424.4 over 18 frames, and appears at full height immediately
  with motion turned off.
- Against a real broker's config the sheet's columns went 367.4/29.6 ->
  244.2/152.8 and `advertised.listeners` went from 19 lines to 2. The panel
  enters from x=440, and the copy that leaves keeps its scroll offset.
- Not verified in WKWebView: background input does not reach the web view - a
  control click on a working entry does nothing either - so the new sidebar
  markup was confirmed live in the dev build by other means, and the page it
  opens is covered by a unit test rather than by a screenshot.
