### PR TITLE
style(website): rebuild the visual system

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -233,8 +233,9 @@ jobs:
           fi
 
           # ARCHITECTURE has no Chinese translation; the Chinese route renders
-          # the English text and must say so.
-          grep -q 'class="mb-6 rounded-lg' website/dist/docs/architecture/index.html || {
+          # the English text and must say so. Keyed on the marker attribute
+          # rather than the notice's classes, which a restyle is free to change.
+          grep -q 'data-untranslated' website/dist/docs/architecture/index.html || {
             echo "the Chinese architecture page lost its untranslated notice" >&2; exit 1; }
 
           # The language switch keeps the reader on the same page, which only

--- a/website/src/components/ChangelogPage.astro
+++ b/website/src/components/ChangelogPage.astro
@@ -77,9 +77,9 @@ const toc = current.sections.flatMap((section, index) =>
               href={pathFor(entry)}
               aria-current={active ? 'page' : undefined}
               class:list={[
-                'flex items-center justify-between gap-2 whitespace-nowrap rounded-lg px-3 py-1.5 font-mono text-caption transition-colors lg:px-3 lg:py-2',
+                'flex items-center justify-between gap-2 whitespace-nowrap rounded-md px-3 py-1.5 font-mono text-caption transition-colors lg:px-3 lg:py-2',
                 active
-                  ? 'bg-secondary font-semibold text-foreground'
+                  ? 'bg-secondary font-medium text-foreground'
                   : 'border border-border text-muted-foreground hover:bg-secondary hover:text-foreground lg:border-transparent',
               ]}
             >
@@ -87,7 +87,7 @@ const toc = current.sections.flatMap((section, index) =>
               {/* Text, not a bare dot: a dot would be aria-hidden, and the rail
                   has to tell a screen reader which release is current. */}
               {entry === latest && (
-                <span class="rounded-full bg-success/10 px-1.5 py-0.5 font-sans text-2xs font-semibold text-success">
+                <span class="rounded-full bg-success/10 px-1.5 py-0.5 font-sans text-2xs font-medium text-success">
                   {c.changelog.latest}
                 </span>
               )}
@@ -101,10 +101,10 @@ const toc = current.sections.flatMap((section, index) =>
   <article class="max-w-measure">
     <header class="border-b border-border pb-4">
       <div class="flex flex-wrap items-center gap-x-3 gap-y-2">
-        <h2 class="text-display-sm font-extrabold tracking-display">{current.version}</h2>
+        <h2 class="text-display-sm font-medium tracking-heading">{current.version}</h2>
         {
           current === latest && (
-            <span class="rounded-full bg-success/10 px-2.5 py-1 text-2xs font-semibold text-success">
+            <span class="rounded-full bg-success/10 px-2.5 py-1 text-2xs font-medium text-success">
               {c.changelog.latest}
             </span>
           )
@@ -131,10 +131,10 @@ const toc = current.sections.flatMap((section, index) =>
     {
       current.sections.map((section, index) => (
         <section id={section.title ? sectionId(section.title, index) : undefined} class="mt-9 scroll-mt-24">
-          {section.title && <h3 class="text-lead font-bold tracking-tight">{section.title}</h3>}
+          {section.title && <h3 class="text-lead font-medium">{section.title}</h3>}
           {section.blocks.map((block) =>
             block.type === 'subheading' ? (
-              <p data-subheading class="mt-6 text-prose font-semibold" set:html={inline(block.text)} />
+              <p data-subheading class="mt-6 text-prose font-medium" set:html={inline(block.text)} />
             ) : block.type === 'paragraph' ? (
               <p class="mt-4 text-prose text-prose-foreground text-pretty" set:html={inline(block.text)} />
             ) : (
@@ -156,7 +156,7 @@ const toc = current.sections.flatMap((section, index) =>
     <div class="mt-12 border-t border-border pt-5">
       <a
         href={`${RELEASES_URL}/tag/v${current.version}`}
-        class="inline-flex items-center gap-1.5 text-ui font-medium transition-colors hover:text-muted-foreground"
+        class="inline-flex items-center gap-1.5 text-ui transition-colors hover:text-muted-foreground"
       >
         {c.changelog.onGitHub} →
       </a>
@@ -171,7 +171,7 @@ const toc = current.sections.flatMap((section, index) =>
         {older ? (
           <a
             href={pathFor(older)}
-            class="inline-flex items-center gap-2 rounded-lg border border-border px-3 py-2 text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground"
+            class="inline-flex items-center gap-2 rounded-md border border-border px-3 py-2 text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground"
           >
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
               <path d="m15 18-6-6 6-6" />
@@ -185,7 +185,7 @@ const toc = current.sections.flatMap((section, index) =>
         {newer && (
           <a
             href={pathFor(newer)}
-            class="inline-flex items-center gap-2 rounded-lg border border-border px-3 py-2 text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground"
+            class="inline-flex items-center gap-2 rounded-md border border-border px-3 py-2 text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground"
           >
             <span class="text-caption">{c.changelog.newer}</span>
             <span class="font-mono font-medium text-foreground">{newer.version}</span>

--- a/website/src/components/DocPage.astro
+++ b/website/src/components/DocPage.astro
@@ -51,9 +51,9 @@ const sourceUrl = `${REPO_URL}/blob/main/docs/${file}`;
               href={localePath(locale, `docs/${candidate}`)}
               aria-current={active ? 'page' : undefined}
               class:list={[
-                'block whitespace-nowrap rounded-lg px-3 py-1.5 text-ui transition-colors lg:py-2',
+                'block whitespace-nowrap rounded-md px-3 py-1.5 text-ui transition-colors lg:py-2',
                 active
-                  ? 'bg-secondary font-semibold text-foreground'
+                  ? 'bg-secondary font-medium text-foreground'
                   : 'border border-border text-muted-foreground hover:bg-secondary hover:text-foreground lg:border-transparent',
               ]}
             >
@@ -68,7 +68,7 @@ const sourceUrl = `${REPO_URL}/blob/main/docs/${file}`;
   <article class="max-w-measure">
     {
       untranslated && (
-        <p class="mb-6 rounded-lg border border-border bg-muted px-4 py-3 text-ui text-muted-foreground">
+        <p data-untranslated class="mb-6 rounded-xl border border-border bg-card px-4 py-3 text-ui text-muted-foreground">
           {c.docs.untranslated}
         </p>
       )
@@ -81,7 +81,7 @@ const sourceUrl = `${REPO_URL}/blob/main/docs/${file}`;
     <div class="mt-12 border-t border-border pt-5">
       <a
         href={sourceUrl}
-        class="inline-flex items-center gap-1.5 text-ui font-medium transition-colors hover:text-muted-foreground"
+        class="inline-flex items-center gap-1.5 text-ui transition-colors hover:text-muted-foreground"
       >
         {c.docs.editOnGitHub} →
       </a>

--- a/website/src/components/Subpage.astro
+++ b/website/src/components/Subpage.astro
@@ -52,7 +52,7 @@ const showToc = toc.length > 1 && !!tocLabel;
 <Base locale={locale} path={path} canonicalPath={canonicalPath} title={title} description={description}>
   <Nav locale={locale} />
 
-  <main id="top" class="mx-auto max-w-[1240px] px-6 py-10 sm:py-14">
+  <main id="top" class="mx-auto max-w-wide px-6 py-10 sm:py-14">
     <nav aria-label={c.nav.breadcrumb} class="text-ui text-muted-foreground">
       <ol class="flex items-center gap-1.5">
         <li>
@@ -70,7 +70,7 @@ const showToc = toc.length > 1 && !!tocLabel;
     {
       heading && (
         <header class="mt-6 max-w-measure">
-          <h1 class="text-title font-bold tracking-heading">{heading}</h1>
+          <h1 class="text-display-sm font-medium tracking-heading">{heading}</h1>
           {lead && <p class="mt-2 text-body text-muted-foreground text-pretty">{lead}</p>}
         </header>
       )
@@ -85,7 +85,7 @@ const showToc = toc.length > 1 && !!tocLabel;
       <!-- A sticky rail on large screens, a scrolling strip of pills above the
            content on small ones. The list itself is the page's. -->
       <nav aria-label={railLabel} class="lg:sticky lg:top-20 lg:self-start">
-        <p class="mb-3 hidden text-ui font-semibold lg:block">{railLabel}</p>
+        <p class="mb-3 hidden text-caption text-subtle-foreground lg:block">{railLabel}</p>
         <slot name="rail" />
       </nav>
 
@@ -96,7 +96,7 @@ const showToc = toc.length > 1 && !!tocLabel;
       {
         showToc && (
           <nav aria-label={tocLabel} data-toc class="hidden xl:sticky xl:top-20 xl:block xl:self-start">
-            <p class="mb-3 text-caption font-semibold text-muted-foreground">{tocLabel}</p>
+            <p class="mb-3 text-caption text-subtle-foreground">{tocLabel}</p>
             <ul class="flex flex-col gap-2 border-l border-border">
               {toc.map((entry) => (
                 <li>

--- a/website/src/components/sections/Community.astro
+++ b/website/src/components/sections/Community.astro
@@ -31,33 +31,32 @@ const stats = [
 ];
 ---
 
-<section id="community" class="border-t border-secondary">
-  <div class="mx-auto max-w-[1120px] px-6 py-20">
-    <h2 class="mb-3 text-center text-display-sm font-bold tracking-heading sm:text-display">
-      {c.community.title}
-    </h2>
-    <p
-      class="mx-auto mb-10 max-w-[620px] text-center text-prose text-muted-foreground text-pretty"
-    >
-      {c.community.lead}
-    </p>
+<section id="community" class="mx-auto max-w-page px-6 py-20 sm:py-28" data-reveal>
+  <h2 class="text-display-sm font-medium tracking-heading">{c.community.title}</h2>
+  <p class="mt-2.5 max-w-measure text-body text-muted-foreground text-pretty">{c.community.lead}</p>
 
-    <dl class="mx-auto grid max-w-[680px] grid-cols-2 gap-3 sm:grid-cols-4">
+  <!-- One bordered group rather than four loose cards: the numbers and the
+       people who produced them are the same claim. -->
+  <div class="mt-9 overflow-hidden rounded-2xl border border-border bg-card">
+    <!-- Every cell draws its own right and bottom edge and the negative margins
+         push the outermost pair past the clipped corner, so the grid needs no
+         per-index rules and stays correct when it reflows to two columns. -->
+    <dl class="-mb-px -mr-px grid grid-cols-2 sm:grid-cols-4">
       {
         stats.map((stat) => (
           /* Term first, as a <dl> requires; reversed visually so the number
              stays on top. */
-          <div class="flex flex-col-reverse rounded-xl border border-border bg-muted px-4 py-5 text-center">
-            <dt class="mt-1 text-caption text-muted-foreground">{stat.label}</dt>
-            <dd class="text-title font-bold tracking-tight tabular-nums">{stat.value}</dd>
+          <div class="flex flex-col-reverse border-b border-r border-border px-5 py-6">
+            <dt class="mt-1.5 text-caption text-muted-foreground">{stat.label}</dt>
+            <dd class="text-title font-medium tabular-nums">{stat.value}</dd>
           </div>
         ))
       }
     </dl>
 
-    <div class="mt-10 flex flex-col items-center gap-4">
+    <div class="border-t border-border px-5 py-6">
       <p class="text-caption text-subtle-foreground">{c.community.builtBy}</p>
-      <ul class="flex flex-wrap justify-center gap-3">
+      <ul class="mt-3.5 flex flex-wrap gap-2.5">
         {
           COMMUNITY.contributors.map((person) => {
             const image = avatarFor(person.avatar);
@@ -65,7 +64,7 @@ const stats = [
               <li>
                 <a
                   href={person.htmlUrl}
-                  class="flex items-center gap-2.5 rounded-full border border-border bg-background py-1.5 pl-1.5 pr-4 transition-colors hover:bg-secondary"
+                  class="flex items-center gap-2.5 rounded-full border border-border py-1.5 pl-1.5 pr-4 transition-colors hover:bg-secondary"
                 >
                   {image ? (
                     <Image
@@ -79,7 +78,7 @@ const stats = [
                   ) : (
                     <span
                       aria-hidden="true"
-                      class="flex size-8 items-center justify-center rounded-full bg-secondary text-ui font-semibold uppercase"
+                      class="flex size-8 items-center justify-center rounded-full bg-secondary text-ui font-medium uppercase"
                     >
                       {person.login.slice(0, 1)}
                     </span>
@@ -92,18 +91,18 @@ const stats = [
         }
       </ul>
     </div>
+  </div>
 
-    <div class="mt-9 flex flex-col items-stretch justify-center gap-3 sm:flex-row sm:items-center">
-      <a
-        href={ISSUES_URL}
-        class="inline-flex h-10 items-center justify-center rounded-lg bg-primary px-5 text-body font-semibold text-primary-foreground transition-colors hover:bg-primary-hover"
-        >{c.community.ctaIssues}</a
-      >
-      <a
-        href={REPO_URL}
-        class="inline-flex h-10 items-center justify-center rounded-lg border border-border bg-background px-5 text-body font-medium transition-colors hover:bg-secondary"
-        >{c.community.ctaRepo}</a
-      >
-    </div>
+  <div class="mt-6 flex flex-col items-stretch gap-2.5 sm:flex-row sm:items-center">
+    <a
+      href={ISSUES_URL}
+      class="inline-flex h-10 items-center justify-center rounded-md bg-primary px-5 text-body font-medium text-primary-foreground transition-colors hover:bg-primary-hover"
+      >{c.community.ctaIssues}</a
+    >
+    <a
+      href={REPO_URL}
+      class="inline-flex h-10 items-center justify-center rounded-md border border-border px-5 text-body font-medium transition-colors hover:bg-secondary"
+      >{c.community.ctaRepo}</a
+    >
   </div>
 </section>

--- a/website/src/components/sections/DownloadSection.astro
+++ b/website/src/components/sections/DownloadSection.astro
@@ -79,57 +79,53 @@ const cards = [
 ] as const;
 ---
 
-<section id="download" class="border-t border-border bg-muted">
-  <div class="mx-auto max-w-[1120px] px-6 py-20">
-    <h2 class="mb-3 text-center text-display-sm font-bold tracking-heading sm:text-display">
-      {d.title}
-    </h2>
-    <p class="mb-11 text-center text-prose text-muted-foreground">
-      {d.leadPrefix} {RELEASE.tag} · {beforeChecksums}
-      {
-        RELEASE.checksums ? (
-          <a href={RELEASE.checksums} class="font-medium text-foreground underline underline-offset-[3px]">
-            SHA256SUMS.txt
-          </a>
-        ) : (
-          'SHA256SUMS.txt'
-        )
-      }
-      {afterChecksums}
-    </p>
+<section id="download" class="mx-auto max-w-page px-6 py-20 sm:py-28" data-reveal>
+  <h2 class="text-display-sm font-medium tracking-heading">{d.title}</h2>
+  <p class="mt-2.5 max-w-measure text-body text-muted-foreground text-pretty">
+    {d.leadPrefix} {RELEASE.tag} · {beforeChecksums}
+    {
+      RELEASE.checksums ? (
+        <a href={RELEASE.checksums} class="text-foreground underline underline-offset-[3px] decoration-border-strong transition-colors hover:decoration-foreground">
+          SHA256SUMS.txt
+        </a>
+      ) : (
+        'SHA256SUMS.txt'
+      )
+    }
+    {afterChecksums}
+  </p>
 
-    <div class="grid gap-5 md:grid-cols-3">
-      {
-        cards.map((card) => (
-          <div class="flex flex-col gap-3.5 rounded-xl border border-border bg-card p-6 shadow-sm">
-            <div class="flex items-start gap-3">
-              <PlatformIcon platform={card.id} size={20} class="mt-0.5 shrink-0" />
-              <div>
-                <div class="text-lead font-bold">{card.platform.name}</div>
-                <div class="mt-0.5 text-caption text-subtle-foreground">
-                  {card.platform.requirement}
-                </div>
+  <div class="mt-9 grid gap-3 md:grid-cols-3">
+    {
+      cards.map((card) => (
+        <div class="flex flex-col gap-4 rounded-2xl border border-border bg-card p-6">
+          <div class="flex items-start gap-3">
+            <PlatformIcon platform={card.id} size={19} class="mt-0.5 shrink-0" />
+            <div>
+              <div class="text-prose font-medium">{card.platform.name}</div>
+              <div class="mt-0.5 text-caption text-subtle-foreground">
+                {card.platform.requirement}
               </div>
             </div>
-            <PlatformPicker
-              cta={card.platform.cta}
-              mirror={d.mirror}
-              segments={card.segments}
-              variants={card.variants}
-            />
           </div>
-        ))
-      }
-    </div>
-
-    <p class="mt-7 text-center text-caption text-muted-foreground">
-      {d.noteMac}{' '}
-      <a href={installDoc} class="font-medium underline underline-offset-[3px]">{d.noteMacLink}</a>
-      <br />
-      {d.noteLinux}{' '}
-      <a href={RELEASES_URL} class="font-medium underline underline-offset-[3px]">
-        {d.noteLinuxLink}
-      </a>
-    </p>
+          <PlatformPicker
+            cta={card.platform.cta}
+            mirror={d.mirror}
+            segments={card.segments}
+            variants={card.variants}
+          />
+        </div>
+      ))
+    }
   </div>
+
+  <p class="mt-6 text-caption text-muted-foreground">
+    {d.noteMac}{' '}
+    <a href={installDoc} class="underline underline-offset-[3px] decoration-border-strong transition-colors hover:decoration-foreground">{d.noteMacLink}</a>
+    <br />
+    {d.noteLinux}{' '}
+    <a href={RELEASES_URL} class="underline underline-offset-[3px] decoration-border-strong transition-colors hover:decoration-foreground">
+      {d.noteLinuxLink}
+    </a>
+  </p>
 </section>

--- a/website/src/components/sections/Drivers.astro
+++ b/website/src/components/sections/Drivers.astro
@@ -8,23 +8,22 @@ const { locale } = Astro.props;
 const c = t(locale);
 ---
 
-<section id="drivers" class="mt-10 border-b border-secondary">
-  <div
-    class="mx-auto flex max-w-[1120px] flex-wrap items-center justify-center gap-x-[22px] gap-y-3 px-6 py-6 text-body"
-  >
-    <span class="text-caption tracking-wider text-subtle-foreground">{c.drivers.label}</span>
+<section id="drivers" class="mx-auto max-w-page px-6 py-20 sm:py-28" data-reveal>
+  <h2 class="text-display-sm font-medium tracking-heading">{c.drivers.label}</h2>
+  <p class="mt-2.5 max-w-measure text-body text-muted-foreground text-pretty">
+    {c.drivers.planned}
+  </p>
+
+  <ul class="mt-8 grid gap-2.5 sm:grid-cols-2 lg:grid-cols-3">
     {
       c.drivers.supported.map((driver) => (
-        <span class="inline-flex items-center gap-1.5 font-semibold">
-          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" class="text-success" aria-hidden="true">
+        <li class="flex min-w-0 items-center gap-2.5 rounded-xl border border-border bg-card px-3.5 py-3 text-body">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" class="shrink-0 text-success" aria-hidden="true">
             <polyline points="20 6 9 17 4 12" />
           </svg>
-          {driver}
-        </span>
+          <span class="min-w-0 truncate">{driver}</span>
+        </li>
       ))
     }
-    <span class="text-subtle-foreground sm:border-l sm:border-border sm:pl-[22px]">
-      {c.drivers.planned}
-    </span>
-  </div>
+  </ul>
 </section>

--- a/website/src/components/sections/Features.astro
+++ b/website/src/components/sections/Features.astro
@@ -8,20 +8,16 @@ const { locale } = Astro.props;
 const c = t(locale);
 ---
 
-<section id="features" class="mx-auto max-w-[1120px] px-6 pb-20 pt-16 sm:pt-[88px]">
-  <h2 class="mb-3 text-center text-display-sm font-bold tracking-heading sm:text-display">
-    {c.features.title}
-  </h2>
-  <p class="mx-auto mb-9 max-w-[680px] text-center text-prose text-muted-foreground text-pretty">
-    {c.features.lead}
-  </p>
+<section id="features" class="mx-auto max-w-page px-6 py-20 sm:py-28" data-reveal>
+  <h2 class="text-display-sm font-medium tracking-heading">{c.features.title}</h2>
+  <p class="mt-2.5 max-w-measure text-body text-muted-foreground text-pretty">{c.features.lead}</p>
 
-  <ul class="grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
+  <ul class="mt-9 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
     {
       c.features.items.map((item) => (
-        <li class="rounded-xl border border-border bg-card p-6">
-          <h3 class="mb-2 text-prose font-bold tracking-tight">{item.title}</h3>
-          <p class="text-body text-muted-foreground text-pretty">{item.body}</p>
+        <li class="rounded-2xl border border-border bg-card p-6">
+          <h3 class="text-prose font-medium">{item.title}</h3>
+          <p class="mt-2 text-body text-muted-foreground text-pretty">{item.body}</p>
         </li>
       ))
     }

--- a/website/src/components/sections/Footer.astro
+++ b/website/src/components/sections/Footer.astro
@@ -18,21 +18,21 @@ const c = t(locale);
     taking it out of first position in the reading order.
   -->
   <div
-    class="mx-auto grid max-w-[1120px] grid-cols-3 gap-x-4 gap-y-7 px-6 py-9 sm:gap-x-6 lg:grid-cols-4 lg:gap-y-10 lg:py-14"
+    class="mx-auto grid max-w-page grid-cols-3 gap-x-4 gap-y-8 px-6 py-10 sm:gap-x-6 lg:grid-cols-4 lg:gap-y-10 lg:py-14"
   >
     <div class="order-last col-span-3 lg:order-first lg:col-span-1">
-      <div class="flex items-center gap-2 text-prose font-bold">
+      <div class="flex items-center gap-2 text-prose font-medium">
         <AppIcon width={22} height={22} class="rounded-[5px]" aria-hidden="true" />
         MQ Studio
       </div>
-      <p class="mt-2 text-ui text-muted-foreground">{c.footer.tagline}</p>
+      <p class="mt-2.5 text-ui text-muted-foreground">{c.footer.tagline}</p>
       <p class="mt-2.5 text-caption text-subtle-foreground">{c.footer.copyright}</p>
     </div>
     {
       c.footer.groups.map((group) => (
         <div class="min-w-0">
-          <div class="mb-2.5 text-ui font-semibold">{group.title}</div>
-          <ul class="flex flex-col gap-1.5 sm:gap-2.5">
+          <div class="mb-3 text-caption text-subtle-foreground">{group.title}</div>
+          <ul class="flex flex-col gap-2 sm:gap-2.5">
             {group.links.map((link) => (
               <li>
                 <a

--- a/website/src/components/sections/Hero.astro
+++ b/website/src/components/sections/Hero.astro
@@ -20,20 +20,23 @@ const targets = {
 };
 ---
 
-<section id="top" class="mx-auto max-w-[1120px] px-6 pb-12 pt-16 text-center sm:pt-[88px]">
+<section id="top" class="mx-auto max-w-page px-6 pb-14 pt-16 text-center sm:pb-16 sm:pt-24">
   <div
-    class="inline-flex items-center gap-2 rounded-full border border-border bg-muted px-3.5 py-1.5 text-caption text-muted-foreground"
+    class="inline-flex items-center gap-2 rounded-full border border-border px-3 py-1 text-caption text-muted-foreground"
   >
     <span class="size-1.5 rounded-full bg-success" aria-hidden="true"></span>
     {RELEASE.tag} {c.hero.badgeSuffix}
   </div>
 
+  <!-- The one place the scale is stepped over: a headline is sized to the
+       viewport, and the zh block cannot reach an arbitrary leading. 1.1 is the
+       compromise that neither crowds the ideographs nor loosens the Latin. -->
   <h1
-    class="mx-auto mb-4.5 mt-5.5 max-w-[760px] text-[34px] font-extrabold leading-[1.12] tracking-display text-balance sm:text-[44px] lg:text-[54px]"
+    class="mx-auto mb-5 mt-6 max-w-[780px] text-[38px] font-medium leading-[1.1] tracking-display text-balance sm:text-[50px] lg:text-[58px]"
   >
     {c.hero.title}
   </h1>
-  <p class="mx-auto max-w-[620px] text-prose text-muted-foreground text-pretty sm:text-lead">
+  <p class="mx-auto max-w-[620px] text-prose text-muted-foreground text-pretty">
     {c.hero.subtitle}
   </p>
 
@@ -41,7 +44,7 @@ const targets = {
        centred independently, so neither edge lined up. Stretching them to a
        shared, capped width puts the stack back on one axis. -->
   <div
-    class="mx-auto mb-3.5 mt-7 flex max-w-[340px] flex-col items-stretch gap-3 sm:max-w-none sm:flex-row sm:items-center sm:justify-center"
+    class="mx-auto mb-4 mt-8 flex max-w-[340px] flex-col items-stretch gap-2.5 sm:max-w-none sm:flex-row sm:items-center sm:justify-center"
   >
     <DownloadMenu
       id="hero-download"
@@ -55,7 +58,7 @@ const targets = {
     />
     <a
       href={localePath(locale, 'docs/install')}
-      class="inline-flex h-11 items-center justify-center rounded-lg border border-border bg-background px-6 text-prose font-medium transition-colors hover:bg-secondary"
+      class="inline-flex h-10 items-center justify-center rounded-md border border-border px-5 text-body font-medium transition-colors hover:bg-secondary"
       >{c.hero.installGuide}</a
     >
   </div>

--- a/website/src/components/sections/Modules.astro
+++ b/website/src/components/sections/Modules.astro
@@ -16,12 +16,10 @@ const c = t(locale);
 const images = { connections, topics, consumers, cluster, alerts };
 ---
 
-<section id="modules" class="border-t border-secondary">
-  <div class="mx-auto max-w-[1120px] px-6 py-20">
-    <h2 class="mb-3 text-center text-display-sm font-bold tracking-heading sm:text-display">
-      {c.modules.title}
-    </h2>
-    <p class="mb-9 text-center text-prose text-muted-foreground text-pretty">{c.modules.lead}</p>
+<section id="modules" class="mx-auto max-w-page px-6 py-20 sm:py-28" data-reveal>
+  <h2 class="text-display-sm font-medium tracking-heading">{c.modules.title}</h2>
+  <p class="mt-2.5 max-w-measure text-body text-muted-foreground text-pretty">{c.modules.lead}</p>
+  <div class="mt-9">
     <ModuleTabs tabs={c.modules.tabs} images={images} />
   </div>
 </section>

--- a/website/src/components/sections/Nav.astro
+++ b/website/src/components/sections/Nav.astro
@@ -39,14 +39,14 @@ const links = [
 <header
   class="sticky top-0 z-50 border-b border-border bg-background/85 backdrop-blur-md supports-[backdrop-filter]:bg-background/85"
 >
-  <nav class="mx-auto flex h-14 max-w-[1120px] items-center gap-3 px-4 sm:gap-4 sm:px-6 lg:gap-7">
-    <a href={localePath(locale)} class="flex flex-none items-center gap-2 whitespace-nowrap text-prose font-bold">
+  <nav class="mx-auto flex h-14 max-w-page items-center gap-3 px-4 sm:gap-4 sm:px-6 lg:gap-7">
+    <a href={localePath(locale)} class="flex flex-none items-center gap-2 whitespace-nowrap text-prose font-medium">
       <AppIcon width={24} height={24} class="rounded-[5px]" aria-hidden="true" />
       MQ Studio
     </a>
     <a
       href={LATEST_URL}
-      class="-ml-2 hidden flex-none rounded-full border border-border bg-muted px-2.5 py-0.5 font-mono text-2xs text-muted-foreground transition-colors hover:text-foreground sm:block"
+      class="-ml-1 hidden flex-none rounded-full border border-border px-2.5 py-0.5 font-mono text-2xs text-muted-foreground transition-colors hover:text-foreground sm:block"
       >{RELEASE.tag}</a
     >
 
@@ -80,7 +80,7 @@ const links = [
       <details class="relative lg:hidden" data-nav-menu>
         <summary
           aria-label={c.nav.menu}
-          class="inline-flex size-[34px] cursor-pointer list-none items-center justify-center rounded-md border border-border bg-background transition-colors hover:bg-secondary focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring [&::-webkit-details-marker]:hidden"
+          class="inline-flex size-[34px] cursor-pointer list-none items-center justify-center rounded-md border border-border transition-colors hover:bg-secondary focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring [&::-webkit-details-marker]:hidden"
         >
           <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true">
             <path d="M3 6h18M3 12h18M3 18h18" />
@@ -94,7 +94,7 @@ const links = [
               <a
                 href={link.href}
                 aria-current={link.current ? 'page' : undefined}
-                class="block rounded-md px-2.5 py-2 text-ui font-medium transition-colors hover:bg-accent aria-[current=page]:bg-secondary"
+                class="block rounded-md px-2.5 py-2 text-ui transition-colors hover:bg-accent aria-[current=page]:bg-secondary"
               >
                 {link.label}
               </a>
@@ -102,19 +102,19 @@ const links = [
           }
           <a
             href={REPO_URL}
-            class="block rounded-md px-2.5 py-2 text-ui font-medium transition-colors hover:bg-accent"
+            class="block rounded-md px-2.5 py-2 text-ui transition-colors hover:bg-accent"
             >{c.nav.github}</a
           >
           <a
             href={otherHref}
-            class="block rounded-md px-2.5 py-2 text-ui font-medium transition-colors hover:bg-accent sm:hidden"
+            class="block rounded-md px-2.5 py-2 text-ui transition-colors hover:bg-accent sm:hidden"
             >{c.nav.languageLabel}</a
           >
         </div>
       </details>
       <a
         href={REPO_URL}
-        class="hidden h-[34px] items-center gap-1.5 rounded-md border border-border bg-background px-3.5 text-ui font-medium transition-colors hover:bg-secondary lg:inline-flex"
+        class="hidden h-[34px] items-center gap-1.5 rounded-md border border-border px-3.5 text-ui transition-colors hover:bg-secondary lg:inline-flex"
       >
         <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-muted-foreground" aria-hidden="true">
           <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"></polygon>

--- a/website/src/components/sections/Roadmap.astro
+++ b/website/src/components/sections/Roadmap.astro
@@ -9,44 +9,41 @@ const c = t(locale);
 const roadmapDoc = localePath(locale, 'docs/roadmap');
 ---
 
-<section id="roadmap" class="border-t border-secondary">
-  <div class="mx-auto flex max-w-[1120px] flex-wrap items-center gap-8 px-6 py-14">
-    <div class="min-w-0 flex-1 sm:min-w-[300px]">
-      <h2 class="mb-2 text-title font-bold tracking-heading">{c.roadmap.title}</h2>
-      <p class="text-body text-muted-foreground text-pretty">
-        {c.roadmap.body}{' '}
-        <a href={roadmapDoc} class="font-medium text-foreground underline underline-offset-[3px]">
-          {c.roadmap.linkLabel} →
-        </a>
-      </p>
-    </div>
-    <ol class="flex flex-wrap items-center gap-2 text-caption">
-      {
-        c.roadmap.stages.map((stage, index) => (
-          <>
-            <li
-              class:list={[
-                'inline-flex items-center gap-1.5 rounded-full px-3 py-1.5',
-                stage.done
-                  ? 'border border-border bg-background font-medium'
-                  : 'border border-dashed border-border-strong text-muted-foreground',
-              ]}
-            >
-              {stage.done && (
-                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" class="text-success" aria-hidden="true">
-                  <polyline points="20 6 9 17 4 12" />
-                </svg>
-              )}
-              {stage.label}
-            </li>
-            {index < c.roadmap.stages.length - 1 && (
-              <li aria-hidden="true" class="hidden text-border-strong sm:block">
-                —
-              </li>
+<section id="roadmap" class="mx-auto max-w-page px-6 py-20 sm:py-28" data-reveal>
+  <h2 class="text-display-sm font-medium tracking-heading">{c.roadmap.title}</h2>
+  <p class="mt-2.5 max-w-measure text-body text-muted-foreground text-pretty">
+    {c.roadmap.body}{' '}
+    <a href={roadmapDoc} class="text-foreground underline underline-offset-[3px] decoration-border-strong transition-colors hover:decoration-foreground">
+      {c.roadmap.linkLabel} →
+    </a>
+  </p>
+
+  <ol class="mt-8 flex flex-wrap items-center gap-2 text-caption">
+    {
+      c.roadmap.stages.map((stage, index) => (
+        <>
+          <li
+            class:list={[
+              'inline-flex items-center gap-1.5 rounded-full px-3 py-1.5',
+              stage.done
+                ? 'border border-border bg-card'
+                : 'border border-dashed border-border-strong text-muted-foreground',
+            ]}
+          >
+            {stage.done && (
+              <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" class="text-success" aria-hidden="true">
+                <polyline points="20 6 9 17 4 12" />
+              </svg>
             )}
-          </>
-        ))
-      }
-    </ol>
-  </div>
+            {stage.label}
+          </li>
+          {index < c.roadmap.stages.length - 1 && (
+            <li aria-hidden="true" class="hidden text-border-strong sm:block">
+              —
+            </li>
+          )}
+        </>
+      ))
+    }
+  </ol>
 </section>

--- a/website/src/components/sections/Shot.astro
+++ b/website/src/components/sections/Shot.astro
@@ -10,15 +10,17 @@ const { locale } = Astro.props;
 const c = t(locale);
 ---
 
-<section class="mx-auto max-w-[1180px] px-6">
+<!-- Wider than the text column on purpose: the screenshot is the product, and
+     framing it inside the same measure as the copy makes it read as an inset. -->
+<section class="mx-auto max-w-wide px-6">
   <Image
     src={overview}
     alt={c.meta.ogAlt}
     widths={[640, 1024, 1440, 1920]}
-    sizes="(min-width: 1180px) 1132px, 100vw"
+    sizes="(min-width: 1216px) 1168px, 100vw"
     loading="eager"
     fetchpriority="high"
-    class="block w-full rounded-xl border border-border shadow-sm"
+    class="block w-full rounded-2xl border border-border"
   />
-  <p class="mt-2 text-center text-ui text-subtle-foreground">{c.shot.caption}</p>
+  <p class="mt-3 text-center text-caption text-subtle-foreground">{c.shot.caption}</p>
 </section>

--- a/website/src/components/widgets/DownloadMenu.astro
+++ b/website/src/components/widgets/DownloadMenu.astro
@@ -20,7 +20,7 @@ const hero = variant === 'hero';
 ---
 
 <div
-  class:list={['relative flex', hero && 'w-full rounded-lg shadow-sm sm:w-auto']}
+  class:list={['relative flex', hero && 'w-full sm:w-auto']}
   data-menu
   id={id}
 >
@@ -30,7 +30,7 @@ const hero = variant === 'hero';
     class:list={[
       'inline-flex items-center gap-2 bg-primary font-medium text-primary-foreground transition-colors hover:bg-primary-hover',
       hero
-        ? 'h-11 flex-1 justify-center rounded-l-lg px-5 text-prose font-semibold sm:flex-none'
+        ? 'h-10 flex-1 justify-center rounded-l-md px-5 text-body sm:flex-none'
         : 'h-[34px] rounded-l-md px-3.5 text-ui',
     ]}
   >
@@ -79,7 +79,7 @@ const hero = variant === 'hero';
     aria-label={menuLabel}
     class:list={[
       'inline-flex items-center justify-center border-l border-primary-foreground/20 bg-primary text-primary-foreground transition-colors hover:bg-primary-hover focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring',
-      hero ? 'h-11 w-9 rounded-r-lg' : 'h-[34px] w-8 rounded-r-md',
+      hero ? 'h-10 w-9 rounded-r-md' : 'h-[34px] w-8 rounded-r-md',
     ]}
   >
     <svg width={hero ? '15' : '13'} height={hero ? '15' : '13'} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
@@ -102,7 +102,7 @@ const hero = variant === 'hero';
     {
       groups.map((group) => (
         <div role="group" aria-label={group.name}>
-          <div class="flex items-center gap-1.5 px-2.5 pb-1 pt-2 text-2xs font-semibold tracking-wide text-subtle-foreground">
+          <div class="flex items-center gap-1.5 px-2.5 pb-1 pt-2 text-2xs font-medium tracking-wide text-subtle-foreground">
             <PlatformIcon platform={group.platform} size={13} class="opacity-75" />
             {group.name}
           </div>

--- a/website/src/components/widgets/ModuleTabs.astro
+++ b/website/src/components/widgets/ModuleTabs.astro
@@ -12,16 +12,16 @@ const { tabs, images } = Astro.props;
 
 // Classes lifted from the shadcn Tabs primitive, minus the dark-mode and
 // vertical-orientation branches this page never enters.
-const list = 'inline-flex w-fit items-center justify-center gap-1 rounded-[10px] bg-secondary p-1';
+const list = 'inline-flex w-fit items-center justify-center gap-1 rounded-full border border-border p-1';
 const trigger =
-  'relative inline-flex items-center justify-center gap-1.5 whitespace-nowrap rounded-md border border-transparent px-3.5 py-1.5 text-ui font-medium text-foreground/60 transition-all hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1 focus-visible:outline-ring aria-selected:bg-background aria-selected:text-foreground aria-selected:shadow-sm';
+  'relative inline-flex items-center justify-center gap-1.5 whitespace-nowrap rounded-full border border-transparent px-3.5 py-1.5 text-ui text-muted-foreground transition-colors hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1 focus-visible:outline-ring aria-selected:bg-secondary aria-selected:text-foreground';
 ---
 
 <div data-tabs>
   <!-- The five labels come to within a few px of a 375px viewport, and a
        translation or a different font would push them over; scrolling the strip
        is better than letting it break the layout. -->
-  <div class="mb-7 flex justify-start overflow-x-auto sm:justify-center [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+  <div class="mb-6 flex justify-start overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
     <div class={list} role="tablist">
       {
         tabs.map((tab, index) => (
@@ -50,10 +50,10 @@ const trigger =
         hidden={index !== 0}
         class="outline-none"
       >
-        <div class="grid items-center gap-9 rounded-2xl border border-border bg-muted p-6 sm:p-9 lg:grid-cols-[360px_1fr]">
+        <div class="grid items-center gap-8 rounded-2xl border border-border bg-card p-6 sm:p-8 lg:grid-cols-[340px_1fr]">
           <div>
-            <h3 class="mb-2.5 text-title-sm font-bold tracking-tight">{tab.title}</h3>
-            <p class="mb-4.5 text-body text-muted-foreground text-pretty">{tab.desc}</p>
+            <h3 class="mb-2.5 text-title-sm font-medium">{tab.title}</h3>
+            <p class="mb-5 text-body text-muted-foreground text-pretty">{tab.desc}</p>
             <ul class="flex flex-col gap-2.5">
               {tab.points.map((point) => (
                 <li class="flex items-start gap-2.5 text-body">
@@ -69,9 +69,9 @@ const trigger =
             src={images[tab.id]!}
             alt={tab.alt}
             widths={[640, 1024, 1440]}
-            sizes="(min-width: 1024px) 700px, 100vw"
+            sizes="(min-width: 1024px) 640px, 100vw"
             loading={index === 0 ? 'eager' : 'lazy'}
-            class="block w-full min-w-0 rounded-lg border border-border"
+            class="block w-full min-w-0 rounded-xl border border-border"
           />
         </div>
       </div>

--- a/website/src/components/widgets/PlatformPicker.astro
+++ b/website/src/components/widgets/PlatformPicker.astro
@@ -30,9 +30,9 @@ const initialKey = segments.map((segment) => segment.defaultValue).join(':');
 const initial = variants.find((variant) => variant.key === initialKey) ?? variants[0]!;
 
 // Classes lifted from the shadcn ToggleGroup primitive.
-const group = 'flex w-fit items-center gap-1 rounded-lg bg-secondary p-1';
+const group = 'flex w-fit items-center gap-1 rounded-full border border-border p-1';
 const item =
-  'inline-flex h-7 items-center justify-center whitespace-nowrap rounded-md bg-transparent px-2.5 text-caption font-medium outline-none transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 aria-checked:bg-background aria-checked:text-accent-foreground aria-checked:shadow-sm';
+  'inline-flex h-7 items-center justify-center whitespace-nowrap rounded-full bg-transparent px-3 text-caption text-muted-foreground outline-none transition-colors hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 aria-checked:bg-secondary aria-checked:text-foreground';
 ---
 
 <div
@@ -65,7 +65,7 @@ const item =
   <a
     href={initial.url}
     data-picker-link
-    class="mt-auto inline-flex h-10 shrink-0 items-center justify-center gap-2 rounded-lg bg-primary text-body font-semibold text-primary-foreground transition-colors hover:bg-primary-hover"
+    class="mt-auto inline-flex h-10 shrink-0 items-center justify-center gap-2 rounded-md bg-primary text-body font-medium text-primary-foreground transition-colors hover:bg-primary-hover"
   >
     <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
       <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />

--- a/website/src/data/community.json
+++ b/website/src/data/community.json
@@ -1,15 +1,15 @@
 {
-  "stars": 39,
-  "forks": 4,
-  "openIssues": 1,
+  "stars": 61,
+  "forks": 6,
+  "openIssues": 2,
   "watchers": 2,
   "contributors": [
     {
       "login": "amigoer",
-      "contributions": 555,
+      "contributions": 883,
       "htmlUrl": "https://github.com/amigoer",
       "avatar": "amigoer.png"
     }
   ],
-  "generatedAt": "2026-09-01T16:04:41.630Z"
+  "generatedAt": "2026-09-12T06:26:35.269Z"
 }

--- a/website/src/layouts/Base.astro
+++ b/website/src/layouts/Base.astro
@@ -99,7 +99,7 @@ const jsonLd = {
     <meta name="twitter:image" content={ogUrl.href} />
 
     <meta name="theme-color" media="(prefers-color-scheme: light)" content="#ffffff" />
-    <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#09090b" />
+    <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#0e0e11" />
 
     <!--
       Blocking on purpose, and before the stylesheet: deferring this would paint

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -11,35 +11,41 @@
  * shadcn/ui tokens for the marketing site. Deliberately NOT shared with
  * frontend/src/design/tokens.css: that layer is the desktop shell's, drawn at a
  * 13px root and scaled by document zoom, while this is an ordinary 16px page.
- * Values are the zinc scale, matching the design canvas the page was drawn from.
+ *
+ * Surfaces and borders are a mix of the foreground into transparent rather than
+ * a ladder of opaque greys. One declaration then reads correctly on the page,
+ * inside a card, and inside a card nested in a card - which is what lets a
+ * grouped block stack two levels without inventing a third grey - and the
+ * .dark block below only has to restate the two ends of the scale.
  */
 :root {
   --background: #ffffff;
   --foreground: #09090b;
-  --card: #ffffff;
-  --card-foreground: #09090b;
+  --card: color-mix(in oklab, var(--foreground) 2.5%, transparent);
+  --card-foreground: var(--foreground);
+  /* Menus float over content, so these two stay opaque. */
   --popover: #ffffff;
   --popover-foreground: #09090b;
   --primary: #18181b;
   --primary-foreground: #fafafa;
-  --secondary: #f4f4f5;
-  --secondary-foreground: #18181b;
-  --muted: #fafafa;
-  --muted-foreground: #71717a;
-  --accent: #f4f4f5;
-  --accent-foreground: #18181b;
+  --secondary: color-mix(in oklab, var(--foreground) 5%, transparent);
+  --secondary-foreground: var(--foreground);
+  --muted: color-mix(in oklab, var(--foreground) 2.5%, transparent);
+  --muted-foreground: color-mix(in oklab, var(--foreground) 58%, var(--background));
+  --accent: color-mix(in oklab, var(--foreground) 6%, transparent);
+  --accent-foreground: var(--foreground);
   --destructive: #dc2626;
   --destructive-foreground: #fafafa;
   --success: #16a34a;
-  --border: #e4e4e7;
-  --input: #e4e4e7;
+  --border: color-mix(in oklab, var(--foreground) 10%, transparent);
+  --input: var(--border);
   --ring: #09090b;
-  /* The canvas draws a third, lighter grey for filenames and captions that the
-     shadcn scale has no slot for. */
-  --subtle-foreground: #a1a1aa;
+  /* A third, lighter grey for filenames and captions that the shadcn scale has
+     no slot for. */
+  --subtle-foreground: color-mix(in oklab, var(--foreground) 42%, var(--background));
   /* Dashed roadmap pills and the separators between them need more contrast
      than a card border, which is what --border is sized for. */
-  --border-strong: #d4d4d8;
+  --border-strong: color-mix(in oklab, var(--foreground) 20%, transparent);
   /* Solid-fill buttons darken on hover in light mode and lighten in dark, so
      the shade cannot be a literal zinc step in the markup. */
   --primary-hover: #27272a;
@@ -54,44 +60,34 @@
   --radius: 0.5rem;
   /*
    * Long-form text. --muted-foreground is tuned for short marketing copy and
-   * only clears 5:1 on white; a page of prose wants more. Mixing against the
-   * background keeps one declaration correct in both themes, because .dark
-   * sits on the same element this is declared on.
+   * only clears 5:1 on white; a page of prose wants more.
    */
   --prose-foreground: color-mix(in oklab, var(--foreground) 78%, var(--background));
 }
 
 /*
- * Applied by the blocking script in Base.astro before first paint. The ladder is
- * page -> section -> card -> control, so surfaces stay distinguishable without
- * borders doing all the work: #09090b < #131316 < #1a1a1e < #27272a.
+ * Applied by the blocking script in Base.astro before first paint. Only the two
+ * ends of the scale and the opaque exceptions are restated; everything above is
+ * mixed from --foreground and --background and follows on its own.
+ *
+ * The ground is lifted off pure black on purpose: a hairline card border is
+ * white at 10%, and it does not read as an edge until the surface under it has
+ * somewhere to sit.
  */
 .dark {
-  --background: #09090b;
+  --background: #0e0e11;
   --foreground: #fafafa;
-  --card: #1a1a1e;
-  --card-foreground: #fafafa;
-  --popover: #1a1a1e;
+  --popover: #17171b;
   --popover-foreground: #fafafa;
   --primary: #fafafa;
   --primary-foreground: #18181b;
   --primary-hover: #e4e4e7;
-  --secondary: #27272a;
-  --secondary-foreground: #fafafa;
-  --muted: #131316;
-  --muted-foreground: #a1a1aa;
-  --accent: #27272a;
-  --accent-foreground: #fafafa;
   --destructive: #ef4444;
   --destructive-foreground: #fafafa;
   /* Lifted from 600 to 500: the darker green does not carry on a dark ground. */
   --success: #22c55e;
-  --border: #27272a;
-  --input: #27272a;
   --ring: #d4d4d8;
-  --subtle-foreground: #71717a;
-  --border-strong: #3f3f46;
-  --banner: #27272a;
+  --banner: #1c1c21;
   --banner-foreground: #fafafa;
   --banner-muted: #a1a1aa;
 }
@@ -137,10 +133,14 @@
 }
 
 /*
- * The site's type scale: ten steps, each carrying its own line-height, so a
+ * The site's type scale: nine steps, each carrying its own line-height, so a
  * component picks a role (text-ui, text-prose) rather than a pixel value.
  * Static because .doc-prose reads these directly and must not depend on a
  * utility happening to be used somewhere.
+ *
+ * Headings are set in the 500-600 range, not 700-800. At this scale the size
+ * already separates a heading from its paragraph, and the extra weight only
+ * costs the page its evenness of colour.
  */
 @theme static {
   --text-2xs: 11px;
@@ -159,30 +159,30 @@
   --text-title-sm--line-height: 1.3;
   --text-title: 24px;
   --text-title--line-height: 1.25;
-  --text-display-sm: 28px;
+  --text-display-sm: 30px;
   --text-display-sm--line-height: 1.2;
-  --text-display: 34px;
-  --text-display--line-height: 1.15;
 
-  --tracking-display: -0.03em;
-  --tracking-heading: -0.02em;
+  --tracking-display: -0.025em;
+  /* Section headings sit at 30px, where negative tracking starts to close the
+     counters rather than tighten the line. */
+  --tracking-heading: 0em;
 
   /* About 45 Chinese or 85 Latin characters at --text-prose. */
   --container-measure: 42.5rem;
+  /* The text column. Everything on the landing page lines up on this. */
+  --container-page: 64rem;
+  /* Screenshots break out past the text column rather than being framed by it. */
+  --container-wide: 76rem;
 }
 
 /*
  * Chinese pages. The utilities resolve to these variables, so one block
- * re-tunes the whole site: PingFang SC stops at Semibold, so an 800 heading
- * only makes its Latin fragments heavier than the characters around them;
- * negative tracking crushes ideographs; and a CJK paragraph needs more
- * leading than a Latin one before it stops looking cramped. Unlayered on
- * purpose, so it wins over Tailwind's theme layer.
+ * re-tunes the whole site: negative tracking crushes ideographs, and a CJK
+ * paragraph needs more leading than a Latin one before it stops looking
+ * cramped. Unlayered on purpose, so it wins over Tailwind's theme layer.
  */
 :root:lang(zh-CN) {
-  --font-weight-extrabold: 700;
   --tracking-display: 0;
-  --tracking-heading: 0;
   --tracking-tight: 0;
   --tracking-wider: 0;
   --text-prose--line-height: 1.8;
@@ -247,6 +247,34 @@ details[data-nav-menu][open] > div {
   animation: menu-in 120ms ease-out;
 }
 
+@keyframes reveal {
+  from {
+    opacity: 0;
+    translate: 0 10px;
+  }
+}
+
+/*
+ * Scroll-linked, so the whole effect costs no JavaScript and cannot delay
+ * anything. Only Chromium implements view(); the @supports guard is what keeps
+ * every other browser showing the section outright instead of running the
+ * animation once on load, which is what an unsupported animation-timeline
+ * falls back to. Anything already on screen at load is past its entry range
+ * and paints in its final state, so the hero never fades in.
+ */
+@supports (animation-timeline: view()) {
+  @media (prefers-reduced-motion: no-preference) {
+    [data-reveal] {
+      animation: reveal linear both;
+      animation-timeline: view();
+      /* A length, not a percentage: a percentage of the cover range is a
+         different distance for a tall section than for a short one, which left
+         the taller ones still transparent well after they had appeared. */
+      animation-range: entry 0% entry 260px;
+    }
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   html {
     scroll-behavior: auto;
@@ -277,8 +305,8 @@ details[data-nav-menu][open] > div {
 .doc-prose h1 {
   margin: 0 0 1rem;
   font-size: var(--text-display-sm);
-  font-weight: var(--font-weight-extrabold);
-  letter-spacing: var(--tracking-display);
+  font-weight: 500;
+  letter-spacing: var(--tracking-heading);
   line-height: var(--text-display-sm--line-height);
   color: var(--foreground);
 }
@@ -288,7 +316,7 @@ details[data-nav-menu][open] > div {
   padding-top: 1.5rem;
   border-top: 1px solid var(--border);
   font-size: var(--text-title-sm);
-  font-weight: var(--font-weight-bold);
+  font-weight: 500;
   letter-spacing: var(--tracking-heading);
   line-height: var(--text-title-sm--line-height);
   color: var(--foreground);
@@ -297,7 +325,7 @@ details[data-nav-menu][open] > div {
 .doc-prose h3 {
   margin: 1.75rem 0 0.625rem;
   font-size: var(--text-lead);
-  font-weight: var(--font-weight-bold);
+  font-weight: 600;
   line-height: var(--text-lead--line-height);
   color: var(--foreground);
 }
@@ -305,7 +333,7 @@ details[data-nav-menu][open] > div {
 .doc-prose h4 {
   margin: 1.5rem 0 0.5rem;
   font-size: var(--text-prose);
-  font-weight: var(--font-weight-semibold);
+  font-weight: 600;
   color: var(--foreground);
 }
 
@@ -334,7 +362,7 @@ details[data-nav-menu][open] > div {
 }
 
 .doc-prose strong {
-  font-weight: var(--font-weight-semibold);
+  font-weight: 600;
   color: var(--foreground);
 }
 
@@ -342,7 +370,7 @@ details[data-nav-menu][open] > div {
   color: var(--foreground);
   text-decoration: underline;
   text-underline-offset: 3px;
-  text-decoration-color: var(--border);
+  text-decoration-color: var(--border-strong);
 }
 .doc-prose a:hover {
   text-decoration-color: var(--foreground);
@@ -350,7 +378,7 @@ details[data-nav-menu][open] > div {
 
 /* Inline code only: `pre code` is left to the highlighter. */
 .doc-prose :not(pre) > code {
-  border-radius: 4px;
+  border-radius: 5px;
   background: var(--secondary);
   padding: 0.1em 0.35em;
   font-family: var(--font-mono);
@@ -362,7 +390,7 @@ details[data-nav-menu][open] > div {
   margin: 1.125rem 0;
   overflow-x: auto;
   border: 1px solid var(--border);
-  border-radius: 10px;
+  border-radius: 12px;
   padding: 0.875rem 1rem;
   font-size: var(--text-ui);
   line-height: 1.7;
@@ -370,7 +398,7 @@ details[data-nav-menu][open] > div {
 
 .doc-prose blockquote {
   margin: 1.125rem 0;
-  border-left: 3px solid var(--border);
+  border-left: 2px solid var(--border-strong);
   padding-left: 1rem;
   color: var(--muted-foreground);
 }
@@ -385,6 +413,8 @@ details[data-nav-menu][open] > div {
 .doc-prose .table-scroll {
   margin: 1.125rem 0;
   overflow-x: auto;
+  border: 1px solid var(--border);
+  border-radius: 12px;
 }
 
 .doc-prose table {
@@ -395,15 +425,20 @@ details[data-nav-menu][open] > div {
 
 .doc-prose th,
 .doc-prose td {
-  border: 1px solid var(--border);
-  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid var(--border);
+  padding: 0.6rem 0.85rem;
   text-align: left;
   vertical-align: top;
 }
 
+/* The wrapper draws the outer edge, so the last row must not draw a second. */
+.doc-prose tr:last-child td {
+  border-bottom: 0;
+}
+
 .doc-prose th {
   background: var(--muted);
-  font-weight: 600;
+  font-weight: 500;
   white-space: nowrap;
   color: var(--foreground);
 }


### PR DESCRIPTION
## What

The marketing site is restyled end to end - landing page, nav, footer, docs
and changelog. Content and routes are untouched; this is the type scale, the
colour tokens and the section rhythm.

- One column: `max-w-page` (1024px) for every section and the nav, with
  `max-w-wide` (1216px) reserved for screenshots, which now break out past the
  text rather than being framed by it.
- Section heads are 30px / weight 500, left-aligned, over a single muted line.
  No `font-bold` or `font-extrabold` survives anywhere in `website/src`.
- Surfaces and borders are `color-mix(in oklab, var(--foreground) N%, ...)`
  instead of a ladder of opaque greys, so `.dark` only restates the two ends of
  the scale and the surfaces that must stay opaque.
- Sections are separated by space, not `border-t`, and fade in on scroll.

## Why

Asked for: the reference is <https://paseo.sh>. The decision was to keep the
light default and the theme toggle and apply the form language to both themes,
because the product screenshots are captured in the light theme and would read
as a white slab on a near-black page.

## How

- Scroll reveal is `animation-timeline: view()` behind `@supports` and
  `prefers-reduced-motion`, so it costs no JavaScript and every browser without
  it shows the section outright. **External JS stays at 0 bytes.** Its range
  ends at a length rather than a percentage of the cover range, which is a
  different distance for a tall section than for a short one.
- Dropping the `--font-weight-extrabold` cap from the `:lang(zh-CN)` block is
  safe now that nothing asks for a weight PingFang SC cannot draw.
- The unused 38px display step is removed rather than left behind.
- `website.yml` asserted the untranslated-doc notice with
  `grep 'class="mb-6 rounded-lg'`, which any restyle of that notice breaks. It
  matches a `data-untranslated` marker now.
- Second commit refreshes `community.json`, which was stale since 2026-09-01
  and still claimed 39 stars.

## Testing

- `npm --prefix website run type-check` - 0 errors, 0 warnings, 0 hints
- `npm --prefix website test` - 5/5
- The full `website.yml` verify step, run the way the workflow runs it
  (`bash --noprofile --norc -e -o pipefail`): 5 tab panels and 10 release
  filenames per locale, 10 changelog pages, 3 doc pages, the language switch
  resolving on all 30 pages, external JS 0 bytes.
- Both locales and both themes reviewed at 1280px; 375px has no horizontal
  overflow (`scrollWidth == clientWidth`).
- The reveal was measured from `getComputedStyle`, not screenshots: 150px into
  view is opacity 0.58 with 4.2px of travel left, settled by 300px.
