### PR TITLE
test(kafka): retry the cross-check CLI under churn

### DIFF
--- a/internal/app/kafka_crosscheck_test.go
+++ b/internal/app/kafka_crosscheck_test.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"errors"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -114,7 +115,16 @@ func requireKafkaCLI(t *testing.T) {
 	})
 }
 
-// cli runs one of Kafka's own tools inside the cluster and returns its output.
+/*
+ * cli runs one of Kafka's own tools inside the cluster and returns its output.
+ *
+ * Retried, because internal/driver/kafka is a second package and therefore a
+ * second process, and `go test` runs it against this same cluster at the same
+ * time as this one. It spends its run creating and deleting topics, so a tool
+ * that walks the whole cluster can have one disappear between its metadata
+ * fetch and its describe - and it exits non-zero for that. That is churn, not
+ * an answer, and re-asking is sound because every call here is a read.
+ */
 func cli(t *testing.T, tool string, args ...string) string {
 	t.Helper()
 	full := append([]string{
@@ -122,11 +132,26 @@ func cli(t *testing.T, tool string, args ...string) string {
 		"--bootstrap-server", kafkaInternal,
 	}, args...)
 
-	output, err := exec.Command("docker", full...).Output()
-	if err != nil {
-		t.Fatalf("%s %v: %v", tool, args, err)
+	var err error
+	for attempt := 0; attempt < 4; attempt++ {
+		if attempt > 0 {
+			time.Sleep(time.Second)
+		}
+		var output []byte
+		if output, err = exec.Command("docker", full...).Output(); err == nil {
+			return string(output)
+		}
 	}
-	return string(output)
+
+	// Output() collects the tool's own diagnosis into the error's Stderr and
+	// prints none of it, so without this the failure reads "exit status 1" and
+	// says nothing about whether the cluster was moving or the call was wrong.
+	var exit *exec.ExitError
+	if errors.As(err, &exit) {
+		t.Fatalf("%s %v: %v: %s", tool, args, err, strings.TrimSpace(string(exit.Stderr)))
+	}
+	t.Fatalf("%s %v: %v", tool, args, err)
+	return ""
 }
 
 // lines drops the blank ones and the warnings the CLI prints to stdout.


### PR DESCRIPTION
## What

`cli()` in the Kafka cross-check re-asks up to four times before failing, and
puts the tool's own stderr in the failure message.

## Why

`E2E (kafka)` failed on `main` at `2f5adba` (run 34678286124):

```
kafka_crosscheck_test.go:385: kafka-topics.sh [--describe --under-replicated-partitions]: exit status 1
--- FAIL: TestLiveKafkaCrossCheck/the_overview_counts_what_the_cluster_counts (10.10s)
```

`go test` runs `internal/app` and `internal/driver/kafka` as two processes
against the same cluster. The interleaved log shows `TestLiveTruncateATopic`,
`TestLiveRebalanceLeaders` and `TestLiveReassignAPartition` running in the
driver package at the moment the app package asked for the cluster-wide count.
`--describe --under-replicated-partitions` walks every topic, so one can be
deleted between its metadata fetch and its describe.

Reproduced against the e2e cluster with topics churning - the tool exits 1 with:

```
ERROR org.apache.kafka.common.errors.UnknownTopicOrPartitionException: (org.apache.kafka.tools.TopicCommand)
```

That is churn, not an answer. The CLI is the *reference* side of the
cross-check, not the thing under test; a reference that throws under load makes
the comparison say nothing.

## How

- Up to four attempts, a second apart. Sound because every call through `cli()`
  is a read.
- `exec.Command(...).Output()` collects the tool's diagnosis into the error's
  `Stderr` and prints none of it, which is why the CI failure read only
  "exit status 1". `errors.As` pulls it into the `Fatalf`.

This does not paper over a regression: the failures it absorbs are the cluster
moving, and a genuine fault still fails after four tries - now with the tool's
reason attached.

## Testing

Measured against the local e2e cluster with six topics being created and
deleted in a loop:

| | raw call failures | failures after up to 4 attempts |
|---|---|---|
| 60 calls | 4 | **0** |

An earlier unretried probe over 60 calls failed once, which is the rate that
makes this bite occasionally rather than every run.

`gofmt` clean, `go vet ./internal/app/` clean, `go test ./internal/app/` passes
offline.

**Not verified locally:** the full live `TestLiveKafkaCrossCheck` re-run with
this change on a quiet cluster. The Docker daemon on the machine went down
partway through that run, so its failures were `connection refused`, not the
change. CI runs exactly that suite on this PR.
